### PR TITLE
Media system audit report

### DIFF
--- a/MIGRATION_PENDING.md
+++ b/MIGRATION_PENDING.md
@@ -1,6 +1,8 @@
 # Database Migration Pending
 
 The schema has been updated to include the `media` table and `media_type` enum.
+Also extended `media` table with enhancement fields.
+
 However, the migration could not be applied automatically in the current environment.
 
 Please run the following command to push the changes to the database:
@@ -16,7 +18,9 @@ npx drizzle-kit push
 ```
 
 ## Changes
+
 - Added `media_type` enum (IMAGE, VIDEO)
+- Added `enhance_status` enum (PENDING, PROCESSING, DONE, FAILED)
 - Added `media` table:
   - id (UUID)
   - userId (UUID)
@@ -25,4 +29,7 @@ npx drizzle-kit push
   - supabaseUrl (text)
   - thumbnailUrl (text)
   - caption (text)
+  - enhancedUrl (text)
+  - enhanceStatus (enhance_status)
+  - enhancedAt (timestamp)
   - createdAt (timestamp)

--- a/MIGRATION_PENDING.md
+++ b/MIGRATION_PENDING.md
@@ -1,0 +1,28 @@
+# Database Migration Pending
+
+The schema has been updated to include the `media` table and `media_type` enum.
+However, the migration could not be applied automatically in the current environment.
+
+Please run the following command to push the changes to the database:
+
+```bash
+npm run db:push
+```
+
+or
+
+```bash
+npx drizzle-kit push
+```
+
+## Changes
+- Added `media_type` enum (IMAGE, VIDEO)
+- Added `media` table:
+  - id (UUID)
+  - userId (UUID)
+  - type (media_type)
+  - muxAssetId (text)
+  - supabaseUrl (text)
+  - thumbnailUrl (text)
+  - caption (text)
+  - createdAt (timestamp)

--- a/MIGRATION_PENDING.md
+++ b/MIGRATION_PENDING.md
@@ -33,3 +33,17 @@ npx drizzle-kit push
   - enhanceStatus (enhance_status)
   - enhancedAt (timestamp)
   - createdAt (timestamp)
+
+- Added `threads` table:
+  - id (UUID)
+  - userId (UUID)
+  - title (text)
+  - createdAt (timestamp)
+  - updatedAt (timestamp)
+
+- Added `messages` table:
+  - id (UUID)
+  - threadId (UUID)
+  - sender (text)
+  - content (text)
+  - createdAt (timestamp)

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -6,6 +6,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes.js";
 import { serveStatic } from "./static.js";
 import tiGuyRouter from "./routes/tiguy.js";
+import mediaRouter from "./routes/media.js";
 import { createServer } from "http";
 // import { tracingMiddleware, getTraceContext, recordException } from "./tracer.js";
 
@@ -93,6 +94,7 @@ app.use((req, res, next) => {
 (async () => {
   try {
     app.use("/api/tiguy", tiGuyRouter);
+    app.use("/api/media", mediaRouter);
     await registerRoutes(httpServer, app);
 
     app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {

--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -621,6 +621,18 @@ export async function registerRoutes(
         expiresAt,
       } as any);
 
+      // [NEW] Sync Images to Media Feed (Videos handled by Mux Webhook)
+      if (post.mediaUrl && !post.muxUploadId && !post.muxAssetId) {
+        // If it's an image (no mux ID), add to Media table immediately
+        await storage.createMedia({
+          userId: req.userId!,
+          type: "IMAGE",
+          thumbnailUrl: post.thumbnailUrl || post.mediaUrl,
+          supabaseUrl: post.mediaUrl,
+          caption: post.caption,
+        });
+      }
+
       // Queue video for processing by Colony OS workers
       const videoQueue = getVideoQueue();
       await videoQueue.add("processVideo", {

--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -28,6 +28,8 @@ import emailAutomation from "./email-automation.js";
 // Import Studio API routes
 import studioRoutes from "./routes/studio.js";
 import enhanceRoutes from "./routes/enhance.js";
+import threadsRouter from "./routes/threads.js";
+import messagesRouter from "./routes/messages.js";
 // [NEW] Import the JWT verifier
 import { verifyAuthToken } from "./supabase-auth.js";
 import aiRoutes from "./routes/ai.routes.js";
@@ -2167,6 +2169,10 @@ export async function registerRoutes(
   }
   // ============ DEEP ENHANCE ROUTES (Moved here) ============
   app.use("/api", requireAuth, enhanceRoutes);
+
+  // [NEW] Threads and Messages
+  app.use("/api/threads", requireAuth, threadsRouter);
+  app.use("/api/messages", requireAuth, messagesRouter);
 
   console.log("✅ Colony OS metrics bridge initialized");
 

--- a/backend/routes/__tests__/dm.test.ts
+++ b/backend/routes/__tests__/dm.test.ts
@@ -1,0 +1,137 @@
+import request from "supertest";
+import express from "express";
+import threadsRouter from "../threads.js";
+import messagesRouter from "../messages.js";
+import { storage } from "../../storage.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock storage
+vi.mock("../../storage.js", () => ({
+  storage: {
+    getThreads: vi.fn(),
+    createThread: vi.fn(),
+    getThreadMessages: vi.fn(),
+    createMessage: vi.fn(),
+    updateThread: vi.fn(),
+    getUser: vi.fn(),
+  },
+}));
+
+// Mock Auth Middleware
+const mockAuthMiddleware = (req: any, res: any, next: any) => {
+  req.userId = "123e4567-e89b-12d3-a456-426614174000";
+  next();
+};
+
+const app = express();
+app.use(express.json());
+app.use("/api/threads", mockAuthMiddleware, threadsRouter);
+app.use("/api/messages", mockAuthMiddleware, messagesRouter);
+
+describe("DM System API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("GET /api/threads", () => {
+    it("should return user threads", async () => {
+      const mockThreads = [
+        { id: "thread-1", userId: "user-1", updatedAt: new Date() },
+      ];
+      (storage.getThreads as any).mockResolvedValue(mockThreads);
+
+      const res = await request(app).get("/api/threads");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(JSON.parse(JSON.stringify(mockThreads)));
+      expect(storage.getThreads).toHaveBeenCalledWith(
+        "123e4567-e89b-12d3-a456-426614174000",
+      );
+    });
+  });
+
+  describe("POST /api/threads", () => {
+    it("should create a new thread", async () => {
+      const mockThread = {
+        id: "thread-new",
+        userId: "user-1",
+        title: "New Chat",
+      };
+      (storage.createThread as any).mockResolvedValue(mockThread);
+
+      const res = await request(app)
+        .post("/api/threads")
+        .send({ title: "New Chat" });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual(mockThread);
+      expect(storage.createThread).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "123e4567-e89b-12d3-a456-426614174000",
+          title: "New Chat",
+        }),
+      );
+    });
+  });
+
+  describe("GET /api/messages/:threadId", () => {
+    it("should return messages for a thread", async () => {
+      const mockMessages = [
+        {
+          id: "msg-1",
+          threadId: "123e4567-e89b-12d3-a456-426614174001",
+          content: "Hello",
+          sender: "user",
+        },
+      ];
+      (storage.getThreadMessages as any).mockResolvedValue(mockMessages);
+
+      const res = await request(app).get(
+        "/api/messages/123e4567-e89b-12d3-a456-426614174001",
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockMessages);
+      expect(storage.getThreadMessages).toHaveBeenCalledWith(
+        "123e4567-e89b-12d3-a456-426614174001",
+      );
+    });
+  });
+
+  describe("POST /api/messages", () => {
+    it("should create a message and trigger Ti-Guy reply", async () => {
+      const mockMessage = {
+        id: "msg-new",
+        threadId: "123e4567-e89b-12d3-a456-426614174001",
+        content: "Hello Ti-Guy",
+        sender: "user",
+      };
+      (storage.createMessage as any).mockResolvedValue(mockMessage);
+
+      const res = await request(app).post("/api/messages").send({
+        threadId: "123e4567-e89b-12d3-a456-426614174001",
+        content: "Hello Ti-Guy",
+        sender: "user",
+      });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual(mockMessage);
+      expect(storage.createMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: "123e4567-e89b-12d3-a456-426614174001",
+          content: "Hello Ti-Guy",
+          sender: "user",
+        }),
+      );
+
+      // We can't easily test the async Ti-Guy reply in this unit test structure without using fake timers
+      // but we can ensure updateThread was called for the user message
+      expect(storage.updateThread).toHaveBeenCalledWith(
+        "123e4567-e89b-12d3-a456-426614174001",
+        expect.objectContaining({
+          updatedAt: expect.any(Date),
+        }),
+      );
+    });
+  });
+});

--- a/backend/routes/__tests__/media.test.ts
+++ b/backend/routes/__tests__/media.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import express from "express";
+import mediaRouter from "../media";
+import { storage } from "../../storage";
+
+// Mock storage
+vi.mock("../../storage", () => ({
+  storage: {
+    createMedia: vi.fn(),
+    getMediaFeed: vi.fn(),
+    getMedia: vi.fn(),
+  },
+}));
+
+// Setup Express app for testing
+const app = express();
+app.use(express.json());
+app.use("/api/media", mediaRouter);
+
+describe("Media Routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("POST /api/media", () => {
+    it("should create media successfully", async () => {
+      const mockMedia = {
+        id: "123e4567-e89b-12d3-a456-426614174000",
+        userId: "123e4567-e89b-12d3-a456-426614174000",
+        type: "IMAGE",
+        thumbnailUrl: "http://thumb.jpg",
+        caption: "Test",
+        createdAt: new Date().toISOString(),
+      };
+
+      (storage.createMedia as any).mockResolvedValue(mockMedia);
+
+      const res = await request(app).post("/api/media").send({
+        userId: "123e4567-e89b-12d3-a456-426614174000",
+        type: "IMAGE",
+        thumbnailUrl: "http://thumb.jpg",
+        caption: "Test",
+      });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual(mockMedia);
+      expect(storage.createMedia).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: "123e4567-e89b-12d3-a456-426614174000",
+          type: "IMAGE",
+        }),
+      );
+    });
+
+    it("should return 400 on validation error", async () => {
+      const res = await request(app).post("/api/media").send({
+        // Missing required fields
+        caption: "Test",
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toHaveProperty("error", "Validation error");
+    });
+  });
+
+  describe("GET /api/media", () => {
+    it("should return paginated feed", async () => {
+      const mockFeed = {
+        items: [{ id: "1" }, { id: "2" }],
+        nextCursor: "2023-01-01",
+      };
+
+      (storage.getMediaFeed as any).mockResolvedValue(mockFeed);
+
+      const res = await request(app).get("/api/media?limit=10");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockFeed);
+      expect(storage.getMediaFeed).toHaveBeenCalledWith(undefined, 10);
+    });
+  });
+
+  describe("GET /api/media/:id", () => {
+    it("should return media item", async () => {
+      const mockItem = { id: "123", type: "VIDEO" };
+      (storage.getMedia as any).mockResolvedValue(mockItem);
+
+      const res = await request(app).get("/api/media/123");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockItem);
+    });
+
+    it("should return 404 if not found", async () => {
+      (storage.getMedia as any).mockResolvedValue(undefined);
+
+      const res = await request(app).get("/api/media/999");
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/backend/routes/media.ts
+++ b/backend/routes/media.ts
@@ -1,0 +1,57 @@
+import { Router, Request, Response } from "express";
+import { storage } from "../storage.js";
+import { insertMediaSchema } from "../../shared/schema.js";
+import { z } from "zod";
+
+const router = Router();
+
+// POST /api/media - Create new media entry
+router.post("/", async (req: Request, res: Response) => {
+  try {
+    // Validate input using Zod schema
+    // The schema omits id and createdAt, but requires userId, type, thumbnailUrl
+    const mediaData = insertMediaSchema.parse(req.body);
+
+    const createdMedia = await storage.createMedia(mediaData);
+    res.status(201).json(createdMedia);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: "Validation error", details: error.errors });
+    }
+    console.error("Error creating media:", error);
+    res.status(500).json({ error: "Failed to create media" });
+  }
+});
+
+// GET /api/media - Paginated feed
+router.get("/", async (req: Request, res: Response) => {
+  try {
+    const cursor = req.query.cursor as string | undefined;
+    const limit = req.query.limit ? parseInt(req.query.limit as string) : 20;
+
+    const result = await storage.getMediaFeed(cursor, limit);
+    res.json(result);
+  } catch (error) {
+    console.error("Error fetching media feed:", error);
+    res.status(500).json({ error: "Failed to fetch media feed" });
+  }
+});
+
+// GET /api/media/:id - Single media item
+router.get("/:id", async (req: Request, res: Response) => {
+  try {
+    const id = req.params.id;
+    const mediaItem = await storage.getMedia(id);
+
+    if (!mediaItem) {
+      return res.status(404).json({ error: "Media not found" });
+    }
+
+    res.json(mediaItem);
+  } catch (error) {
+    console.error(`Error fetching media ${req.params.id}:`, error);
+    res.status(500).json({ error: "Failed to fetch media" });
+  }
+});
+
+export default router;

--- a/backend/routes/messages.ts
+++ b/backend/routes/messages.ts
@@ -1,0 +1,74 @@
+import { Router, Request, Response } from "express";
+import { storage } from "../storage.js";
+import { insertMessageSchema } from "../../shared/schema.js";
+import { z } from "zod";
+
+const router = Router();
+
+// GET /api/messages/:threadId - Get messages for a thread
+router.get("/:threadId", async (req: Request, res: Response) => {
+  try {
+    if (!req.userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    // TODO: Verify user owns the thread
+
+    const messages = await storage.getThreadMessages(req.params.threadId);
+    res.json(messages);
+  } catch (error) {
+    console.error("Error fetching messages:", error);
+    res.status(500).json({ error: "Failed to fetch messages" });
+  }
+});
+
+// POST /api/messages - Create a message
+router.post("/", async (req: Request, res: Response) => {
+  try {
+    if (!req.userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const messageData = insertMessageSchema.parse(req.body);
+
+    // Save user message
+    const message = await storage.createMessage(messageData);
+
+    // Update thread updatedAt
+    await storage.updateThread(message.threadId, { updatedAt: new Date() });
+
+    // Ti-Guy Auto-Reply
+    if (messageData.sender === "user") {
+      // Simulate processing delay
+      setTimeout(async () => {
+        try {
+          const tiGuyReply = "Ben oui, c'est tiguidou! 🦫 (Auto-reply)";
+
+          await storage.createMessage({
+            threadId: message.threadId,
+            sender: "ti-guy",
+            content: tiGuyReply,
+          });
+
+          await storage.updateThread(message.threadId, {
+            updatedAt: new Date(),
+          });
+        } catch (err) {
+          console.error("Ti-Guy reply error:", err);
+        }
+      }, 1000);
+    }
+
+    res.status(201).json(message);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res
+        .status(400)
+        .json({ error: "Validation error", details: error.errors });
+    }
+    console.error("Error creating message:", error);
+    res.status(500).json({ error: "Failed to create message" });
+  }
+});
+
+export default router;

--- a/backend/routes/mux.ts
+++ b/backend/routes/mux.ts
@@ -85,7 +85,7 @@ muxRouter.post("/webhooks/mux", async (req, res) => {
             runModeratorBee(thumbnailUrl)
           ]);
 
-          await storage.updatePostByMuxAssetId(assetId, {
+          const updatedPost = await storage.updatePostByMuxAssetId(assetId, {
             muxPlaybackId: playbackId,
             thumbnailUrl,
             processingStatus: "completed",
@@ -107,6 +107,17 @@ muxRouter.post("/webhooks/mux", async (req, res) => {
             isHidden: !modResult.approved,
             moderatedAt: new Date(),
           });
+
+          // [NEW] Sync to Media Feed
+          if (updatedPost) {
+            await storage.createMedia({
+              userId: updatedPost.userId,
+              type: "VIDEO",
+              muxAssetId: assetId,
+              thumbnailUrl: thumbnailUrl,
+              caption: updatedPost.caption,
+            });
+          }
         }
         break;
       }

--- a/backend/routes/threads.ts
+++ b/backend/routes/threads.ts
@@ -1,0 +1,48 @@
+import { Router, Request, Response } from "express";
+import { storage } from "../storage.js";
+import { insertThreadSchema } from "../../shared/schema.js";
+import { z } from "zod";
+
+const router = Router();
+
+// GET /api/threads - List threads for current user
+router.get("/", async (req: Request, res: Response) => {
+  try {
+    if (!req.userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const threads = await storage.getThreads(req.userId);
+    res.json(threads);
+  } catch (error) {
+    console.error("Error fetching threads:", error);
+    res.status(500).json({ error: "Failed to fetch threads" });
+  }
+});
+
+// POST /api/threads - Create a new thread
+router.post("/", async (req: Request, res: Response) => {
+  try {
+    if (!req.userId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const threadData = insertThreadSchema.parse({
+      ...req.body,
+      userId: req.userId,
+    });
+
+    const thread = await storage.createThread(threadData);
+    res.status(201).json(thread);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res
+        .status(400)
+        .json({ error: "Validation error", details: error.errors });
+    }
+    console.error("Error creating thread:", error);
+    res.status(500).json({ error: "Failed to create thread" });
+  }
+});
+
+export default router;

--- a/backend/services/videoProcessor.ts
+++ b/backend/services/videoProcessor.ts
@@ -1,3 +1,4 @@
+// @deprecated - Use backend/worker.ts instead
 import ffmpeg from "fluent-ffmpeg";
 import fs from "fs";
 import path from "path";

--- a/backend/worker.ts
+++ b/backend/worker.ts
@@ -12,112 +12,99 @@ import { postTiGuyFirstComment } from "./services/engagementService.js";
 import { MemoryMinerBee } from "./ai/bees/memory-miner.js";
 import { PrivacyAuditorBee } from "./ai/bees/privacy-auditor.js";
 import { HiveTask } from "./ai/types.js";
+import { db } from "./storage.js";
+import { media } from "../shared/schema.js";
+import { eq } from "drizzle-orm";
 
 const connection = {
   host: process.env.REDIS_HOST || "localhost",
   port: parseInt(process.env.REDIS_PORT || "6379"),
 };
 
-export const videoWorker = new Worker<VideoProcessingJob>(
-  "processVideo",
+export const videoWorker = new Worker<any>(
+  "zyeute-video-enhance",
   async (job) => {
-    const { postId, userId } = job.data;
-    console.log(`[Worker] Starting job for post ${postId}`);
+    console.log(`[Worker] Processing job ${job.name} (${job.id})`);
 
-    try {
-      // 1. Update Status
-      await updatePostStatus(postId, "processing");
-      await sendProgress(userId, postId, 10, "Downloading");
+    // --- UPSCALE VIDEO PROCESSOR ---
+    if (job.name === "upscale_video") {
+      const { mediaId, muxAssetId, supabaseUrl, userId, filter } = job.data;
+      console.log(`[Worker] Upscaling video for Media ${mediaId}`);
 
-      // 2. Process Video (Download, Transcode, Thumbnail)
-      // This handles download, valid, transcode, filter, thumb generation
-      const processedFiles = await processVideo(job.data);
-
-      await sendProgress(userId, postId, 60, "Scouting");
-
-      // 2.5 Scout Video (AI Enrichment)
-      // We use the low-res version for AI scouting to save memory/tokens
-      let scoutResult = null;
       try {
-        scoutResult = await scoutVideo(processedFiles.videoLow, postId);
+        // Update status to PROCESSING
+        await db
+          .update(media)
+          .set({ enhanceStatus: "PROCESSING" })
+          .where(eq(media.id, mediaId));
 
-        // Safety Patrol: If rejected, we hide the post
-        if (scoutResult && !scoutResult.safetyApproved) {
-          console.warn(
-            `🚨 [Worker] Safety Patrol REJECTED post ${postId}: ${scoutResult.safetyReason}`,
-          );
-          await updatePostStatus(postId, "failed"); // Mark as failed or we could add a 'hidden' status
-          // We'll stop here to prevent notification/upload of bad content
-          throw new Error(
-            `Contenu rejeté par la Patrouille de Sécurité: ${scoutResult.safetyReason}`,
-          );
-        }
-
-        // Automated Engagement: If safe, Ti-Guy leaves the first comment
-        if (scoutResult && scoutResult.safetyApproved) {
-          // Check if user has enabled Ti-Guy comments
-          const isEnabled = await isTiGuyCommentEnabled(userId);
-
-          if (isEnabled) {
-            // Fire and forget engagement so it doesn't block the worker completion
-            postTiGuyFirstComment(postId, {
-              summary: scoutResult.summary,
-              tags: scoutResult.tags,
-            }).catch((e) => console.error("[Worker] Engagement failed:", e));
-          } else {
-            console.log(
-              `[Worker] Ti-Guy comment skipped for user ${userId} (disabled in profile)`,
-            );
+        // Determine download URL
+        let videoUrl = supabaseUrl;
+        if (muxAssetId) {
+          // If Mux, use public playback URL (HLS) or MP4 if available
+          // For simplicity, we'll try the HLS stream or assume download logic handles it
+          // Ideally, we'd get a signed download URL or MP4 URL.
+          // Assuming we use the HLS URL for now as ffmpeg can handle it.
+          // Wait, need playback ID. We don't have it in payload.
+          // But we can assume supabaseUrl is passed if it's there, or we fetch from DB.
+          // Let's rely on what was passed or fetch from DB if needed.
+          if (!videoUrl) {
+            const mediaRecord = await db
+              .select()
+              .from(media)
+              .where(eq(media.id, mediaId))
+              .limit(1);
+            // Mux asset ID doesn't give URL directly.
+            // But we used supabaseUrl as mediaUrl in route.
+            // Let's assume input has a valid URL.
+            throw new Error("No video URL provided for Mux asset");
           }
         }
-      } catch (scoutError: any) {
-        console.error(
-          `[Worker] Scouting failed or rejected for ${postId}:`,
-          scoutError.message,
+
+        if (!videoUrl) throw new Error("No video URL provided");
+
+        // Process Video
+        const processedFiles = await processVideo({
+          videoUrl,
+          userId,
+          postId: "media-" + mediaId, // Placeholder
+          visual_filter: filter,
+        });
+
+        // Upload Enhanced
+        const urls = await uploadProcessedVideo(
+          processedFiles,
+          "media-" + mediaId,
         );
-        if (scoutError.message.includes("Contenu rejeté")) throw scoutError;
-        // If it's just a technical failure, we can continue to upload
+
+        // Update Media
+        await db
+          .update(media)
+          .set({
+            enhancedUrl: urls.videoHighUrl,
+            enhanceStatus: "DONE",
+            enhancedAt: new Date(),
+          })
+          .where(eq(media.id, mediaId));
+
+        console.log(`[Worker] Upscale complete for Media ${mediaId}`);
+        return urls;
+      } catch (error: any) {
+        console.error(`[Worker] Upscale failed for Media ${mediaId}:`, error);
+        await db
+          .update(media)
+          .set({ enhanceStatus: "FAILED" })
+          .where(eq(media.id, mediaId));
+        throw error;
       }
+    }
 
-      await sendProgress(userId, postId, 80, "Uploading");
-
-      // 3. Upload to Storage
-      const urls = await uploadProcessedVideo(processedFiles, postId);
-
-      // 4. Update Database
-      await saveVideoUrls(postId, urls);
-
-      // 5. Trigger AI Transcription (Phase 9)
-      if (urls.videoHighUrl) {
-        console.log(`[Worker] Triggering transcription for post ${postId}`);
-        fetch(
-          `${process.env.VITE_SUPABASE_URL}/functions/v1/transcribe-media`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
-            },
-            body: JSON.stringify({
-              publicationId: postId,
-              mediaUrl: urls.videoHighUrl,
-            }),
-          },
-        ).catch((err) =>
-          console.error(`[Worker] Transcription trigger failed:`, err),
-        );
-      }
-
-      await sendProgress(userId, postId, 100, "Done");
-      await notifyCompletion(userId, postId, true, urls.videoHighUrl);
-
-      console.log(`[Worker] Job completed for post ${postId}`);
-      return urls;
-    } catch (error: any) {
-      console.error(`[Worker] Job failed for post ${postId}:`, error);
-      await updatePostStatus(postId, "failed");
-      await notifyCompletion(userId, postId, false);
-      throw error; // BullMQ handles retry
+    // --- LEGACY PROCESS VIDEO (Keep for compatibility if needed) ---
+    if (job.name === "processVideo" || !job.name) {
+      // ... (Keep existing logic)
+      const { postId, userId } = job.data;
+      // ... (Logic from before)
+      return legacyProcessVideo(job);
     }
   },
   {
@@ -129,6 +116,104 @@ export const videoWorker = new Worker<VideoProcessingJob>(
     },
   },
 );
+
+async function legacyProcessVideo(job: any) {
+  const { postId, userId } = job.data;
+  console.log(`[Worker] Starting legacy job for post ${postId}`);
+
+  try {
+    // 1. Update Status
+    await updatePostStatus(postId, "processing");
+    await sendProgress(userId, postId, 10, "Downloading");
+
+    // 2. Process Video (Download, Transcode, Thumbnail)
+    // This handles download, valid, transcode, filter, thumb generation
+    const processedFiles = await processVideo(job.data);
+
+    await sendProgress(userId, postId, 60, "Scouting");
+
+    // 2.5 Scout Video (AI Enrichment)
+    // We use the low-res version for AI scouting to save memory/tokens
+    let scoutResult = null;
+    try {
+      scoutResult = await scoutVideo(processedFiles.videoLow, postId);
+
+      // Safety Patrol: If rejected, we hide the post
+      if (scoutResult && !scoutResult.safetyApproved) {
+        console.warn(
+          `🚨 [Worker] Safety Patrol REJECTED post ${postId}: ${scoutResult.safetyReason}`,
+        );
+        await updatePostStatus(postId, "failed"); // Mark as failed or we could add a 'hidden' status
+        // We'll stop here to prevent notification/upload of bad content
+        throw new Error(
+          `Contenu rejeté par la Patrouille de Sécurité: ${scoutResult.safetyReason}`,
+        );
+      }
+
+      // Automated Engagement: If safe, Ti-Guy leaves the first comment
+      if (scoutResult && scoutResult.safetyApproved) {
+        // Check if user has enabled Ti-Guy comments
+        const isEnabled = await isTiGuyCommentEnabled(userId);
+
+        if (isEnabled) {
+          // Fire and forget engagement so it doesn't block the worker completion
+          postTiGuyFirstComment(postId, {
+            summary: scoutResult.summary,
+            tags: scoutResult.tags,
+          }).catch((e) => console.error("[Worker] Engagement failed:", e));
+        } else {
+          console.log(
+            `[Worker] Ti-Guy comment skipped for user ${userId} (disabled in profile)`,
+          );
+        }
+      }
+    } catch (scoutError: any) {
+      console.error(
+        `[Worker] Scouting failed or rejected for ${postId}:`,
+        scoutError.message,
+      );
+      if (scoutError.message.includes("Contenu rejeté")) throw scoutError;
+      // If it's just a technical failure, we can continue to upload
+    }
+
+    await sendProgress(userId, postId, 80, "Uploading");
+
+    // 3. Upload to Storage
+    const urls = await uploadProcessedVideo(processedFiles, postId);
+
+    // 4. Update Database
+    await saveVideoUrls(postId, urls);
+
+    // 5. Trigger AI Transcription (Phase 9)
+    if (urls.videoHighUrl) {
+      console.log(`[Worker] Triggering transcription for post ${postId}`);
+      fetch(`${process.env.VITE_SUPABASE_URL}/functions/v1/transcribe-media`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
+        },
+        body: JSON.stringify({
+          publicationId: postId,
+          mediaUrl: urls.videoHighUrl,
+        }),
+      }).catch((err) =>
+        console.error(`[Worker] Transcription trigger failed:`, err),
+      );
+    }
+
+    await sendProgress(userId, postId, 100, "Done");
+    await notifyCompletion(userId, postId, true, urls.videoHighUrl);
+
+    console.log(`[Worker] Job completed for post ${postId}`);
+    return urls;
+  } catch (error: any) {
+    console.error(`[Worker] Job failed for post ${postId}:`, error);
+    await updatePostStatus(postId, "failed");
+    await notifyCompletion(userId, postId, false);
+    throw error; // BullMQ handles retry
+  }
+}
 
 videoWorker.on("completed", (job) => {
   console.log(`[Worker] Job ${job.id} completed!`);

--- a/frontend/src/components/layout/BottomNav.tsx
+++ b/frontend/src/components/layout/BottomNav.tsx
@@ -15,8 +15,8 @@ interface NavItem {
 
 const navItems: NavItem[] = [
   {
-    to: "/",
-    label: "Accueil",
+    to: "/feed",
+    label: "Fil",
     icon: (
       <svg
         className="w-6 h-6"
@@ -28,13 +28,13 @@ const navItems: NavItem[] = [
           strokeLinecap="round"
           strokeLinejoin="round"
           strokeWidth={2}
-          d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+          d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
         />
       </svg>
     ),
     activeIcon: (
       <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
-        <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+        <path d="M4 11h16v8H4zM6 9V7a2 2 0 012-2h8a2 2 0 012 2v2H6z" />
       </svg>
     ),
   },

--- a/frontend/src/components/media/MediaFeed.tsx
+++ b/frontend/src/components/media/MediaFeed.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from "react";
+import { useMediaFeed } from "@/hooks/useMediaFeed";
+import { MediaFeedItem } from "./MediaFeedItem";
+import { MediaViewer } from "./MediaViewer";
+import { Media } from "@/types";
+import { MapleSpinner } from "@/components/ui/MapleSpinner";
+import { ErrorFallback } from "@/components/ErrorBoundary";
+
+export const MediaFeed: React.FC = () => {
+  const { items, loadMoreRef, isLoading, isFetchingNextPage, error, refetch } =
+    useMediaFeed();
+  const [selectedMedia, setSelectedMedia] = useState<Media | null>(null);
+
+  // Optimistic update handler for enhance
+  const handleEnhanceTriggered = (mediaId: string) => {
+    if (selectedMedia && selectedMedia.id === mediaId) {
+      setSelectedMedia({ ...selectedMedia, enhanceStatus: "PROCESSING" });
+    }
+    // Also trigger refetch to update grid
+    // refetch(); // Might be too aggressive, better to wait or use queryClient.setQueryData
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-full min-h-[50vh] bg-black">
+        <MapleSpinner className="text-gold-500" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <ErrorFallback onRetry={() => refetch()} />;
+  }
+
+  return (
+    <div className="min-h-screen w-full pb-24 bg-gradient-to-br from-indigo-900 via-purple-900 to-pink-900">
+      {/* Header Spacer if needed or integrated in parent */}
+
+      {/* Grid Feed */}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2 p-2">
+        {items.map((media) => (
+          <MediaFeedItem
+            key={media.id}
+            media={media}
+            onClick={setSelectedMedia}
+          />
+        ))}
+      </div>
+
+      {/* Empty State */}
+      {!isLoading && items.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-20 text-stone-500">
+          <p>Aucun média pour le moment.</p>
+        </div>
+      )}
+
+      {/* Infinite Scroll Trigger */}
+      <div
+        ref={loadMoreRef}
+        className="h-20 flex justify-center items-center w-full"
+      >
+        {isFetchingNextPage && (
+          <MapleSpinner size="sm" className="text-gold-500" />
+        )}
+      </div>
+
+      {/* Modal Viewer */}
+      {selectedMedia && (
+        <MediaViewer
+          media={selectedMedia}
+          onClose={() => setSelectedMedia(null)}
+          onEnhanceTriggered={handleEnhanceTriggered}
+        />
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/media/MediaFeedItem.tsx
+++ b/frontend/src/components/media/MediaFeedItem.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { Media } from "@/types";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/Avatar";
+import { formatDistanceToNow } from "date-fns";
+import { fr } from "date-fns/locale";
+import { Badge } from "@/components/ui/badge";
+import { MapleSpinner } from "@/components/ui/MapleSpinner";
+import { Play } from "lucide-react";
+
+interface MediaFeedItemProps {
+  media: Media;
+  onClick: (media: Media) => void;
+}
+
+export const MediaFeedItem: React.FC<MediaFeedItemProps> = ({
+  media,
+  onClick,
+}) => {
+  const isVideo = media.type === "VIDEO";
+  const isEnhancing = media.enhanceStatus === "PROCESSING";
+  const isEnhanced = media.enhanceStatus === "DONE";
+  const isFailed = media.enhanceStatus === "FAILED";
+
+  return (
+    <div
+      className="relative aspect-[9/16] w-full overflow-hidden rounded-xl bg-neutral-900 shadow-lg cursor-pointer group touch-manipulation ring-1 ring-white/10"
+      onClick={() => onClick(media)}
+    >
+      {/* Thumbnail / Image */}
+      <img
+        src={
+          media.thumbnailUrl ||
+          media.enhancedUrl ||
+          media.supabaseUrl ||
+          "/placeholder-image.jpg"
+        }
+        alt={media.caption || "Media content"}
+        className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+        loading="lazy"
+      />
+
+      {/* Video Indicator */}
+      {isVideo && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div className="bg-black/40 backdrop-blur-sm rounded-full p-4 border border-white/20 shadow-xl">
+            <Play className="w-8 h-8 text-white fill-white ml-1" />
+          </div>
+        </div>
+      )}
+
+      {/* Overlays */}
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black/90 pointer-events-none" />
+
+      {/* Enhance Status Badge */}
+      <div className="absolute top-3 right-3 flex gap-2 z-10">
+        {isEnhancing && (
+          <Badge
+            variant="outline"
+            className="bg-black/60 border-gold-400 text-gold-400 flex items-center gap-1 backdrop-blur-md"
+          >
+            <MapleSpinner size="sm" />
+            <span className="text-[10px]">Optimisation...</span>
+          </Badge>
+        )}
+        {isEnhanced && (
+          <Badge
+            variant="secondary"
+            className="bg-gold-500 text-black text-[10px] font-black shadow-[0_0_10px_rgba(255,191,0,0.5)] border border-yellow-200"
+          >
+            ✨ HD
+          </Badge>
+        )}
+        {isFailed && (
+          <Badge variant="destructive" className="text-[10px]">
+            Échec
+          </Badge>
+        )}
+      </div>
+
+      {/* User Info & Caption */}
+      <div className="absolute bottom-0 left-0 w-full p-4 text-white z-10">
+        <div className="flex items-center gap-3 mb-2">
+          <Avatar className="w-8 h-8 border border-white/20">
+            <AvatarImage src={media.user?.avatar_url || ""} />
+            <AvatarFallback className="bg-neutral-800 text-xs text-stone-400">
+              {media.user?.username?.substring(0, 2).toUpperCase() || "??"}
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex flex-col">
+            <span className="text-sm font-bold leading-none text-white drop-shadow-md">
+              {media.user?.display_name ||
+                media.user?.username ||
+                "Utilisateur"}
+            </span>
+            <span className="text-[10px] text-stone-400">
+              {formatDistanceToNow(new Date(media.createdAt), {
+                addSuffix: true,
+                locale: fr,
+              })}
+            </span>
+          </div>
+        </div>
+
+        {media.caption && (
+          <p className="text-sm text-stone-200 line-clamp-2 drop-shadow-sm">
+            {media.caption}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/media/MediaViewer.tsx
+++ b/frontend/src/components/media/MediaViewer.tsx
@@ -1,0 +1,175 @@
+import React, { useState, useEffect } from "react";
+import { Media } from "@/types";
+import { X, Share2, Wand2, Play } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { enhanceMedia } from "@/services/api";
+import { MapleSpinner } from "@/components/ui/MapleSpinner";
+import { Badge } from "@/components/ui/badge";
+
+interface MediaViewerProps {
+  media: Media | null;
+  onClose: () => void;
+  onEnhanceTriggered?: (mediaId: string) => void;
+}
+
+export const MediaViewer: React.FC<MediaViewerProps> = ({
+  media,
+  onClose,
+  onEnhanceTriggered,
+}) => {
+  const [isPlaying, setIsPlaying] = useState(true);
+  const videoRef = React.useRef<HTMLVideoElement>(null);
+  const [isEnhancing, setIsEnhancing] = useState(false);
+
+  useEffect(() => {
+    if (media?.enhanceStatus === "PROCESSING") {
+      setIsEnhancing(true);
+    } else {
+      setIsEnhancing(false);
+    }
+  }, [media]);
+
+  if (!media) return null;
+
+  const isVideo = media.type === "VIDEO";
+  const enhancedUrl = media.enhancedUrl;
+  const originalUrl = media.supabaseUrl;
+  const displayUrl = enhancedUrl || originalUrl;
+
+  const handleEnhance = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isEnhancing || media.enhanceStatus === "DONE") return;
+    setIsEnhancing(true);
+    try {
+      await enhanceMedia(media.id);
+      onEnhanceTriggered?.(media.id);
+    } catch (error) {
+      console.error("Enhance failed", error);
+      setIsEnhancing(false);
+    }
+  };
+
+  const togglePlay = () => {
+    if (videoRef.current) {
+      if (videoRef.current.paused) {
+        videoRef.current.play();
+        setIsPlaying(true);
+      } else {
+        videoRef.current.pause();
+        setIsPlaying(false);
+      }
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black flex flex-col animate-in fade-in duration-200">
+      {/* Top Bar */}
+      <div className="absolute top-0 left-0 right-0 p-4 z-20 flex justify-between items-start bg-gradient-to-b from-black/80 to-transparent pointer-events-none">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          className="text-white hover:bg-white/10 rounded-full pointer-events-auto"
+        >
+          <X className="w-6 h-6" />
+        </Button>
+      </div>
+
+      {/* Main Content */}
+      <div
+        className="flex-1 flex items-center justify-center relative overflow-hidden bg-black"
+        onClick={isVideo ? togglePlay : undefined}
+      >
+        {isVideo ? (
+          <>
+            <video
+              ref={videoRef}
+              src={displayUrl || ""}
+              poster={media.thumbnailUrl}
+              className="max-h-full max-w-full object-contain"
+              autoPlay
+              loop
+              playsInline
+            />
+            {/* Play/Pause Overlay Indicator */}
+            {!isPlaying && (
+              <div className="absolute inset-0 flex items-center justify-center bg-black/40 pointer-events-none">
+                <Play className="w-16 h-16 text-white/80 fill-white/80" />
+              </div>
+            )}
+          </>
+        ) : (
+          <img
+            src={displayUrl || ""}
+            alt={media.caption || "Full screen media"}
+            className="max-h-full max-w-full object-contain"
+          />
+        )}
+      </div>
+
+      {/* Bottom Bar */}
+      <div className="absolute bottom-0 left-0 right-0 p-6 z-20 bg-gradient-to-t from-black/90 via-black/50 to-transparent pointer-events-none">
+        <div className="pointer-events-auto">
+          {/* Caption */}
+          {media.caption && (
+            <p className="text-white mb-4 line-clamp-3 text-shadow-sm font-medium">
+              {media.caption}
+            </p>
+          )}
+
+          {/* Actions */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              {/* Enhance Button */}
+              {(media.enhanceStatus === "PENDING" ||
+                media.enhanceStatus === "FAILED") && (
+                <Button
+                  onClick={handleEnhance}
+                  disabled={isEnhancing}
+                  size="sm"
+                  className="bg-gold-500 hover:bg-gold-600 text-black font-bold shadow-glow transition-all active:scale-95"
+                >
+                  {isEnhancing ? (
+                    <>
+                      <MapleSpinner size="sm" className="mr-2 text-black" />
+                      Optimisation...
+                    </>
+                  ) : (
+                    <>
+                      <Wand2 className="w-4 h-4 mr-2" />
+                      Améliorer (IA)
+                    </>
+                  )}
+                </Button>
+              )}
+
+              {media.enhanceStatus === "PROCESSING" && (
+                <Badge
+                  variant="outline"
+                  className="bg-black/40 border-gold-400 text-gold-400 h-9 px-3"
+                >
+                  <MapleSpinner size="sm" className="mr-2" />
+                  Traitement...
+                </Badge>
+              )}
+
+              {media.enhanceStatus === "DONE" && (
+                <Badge className="bg-green-500/90 text-white font-bold h-9 px-3 shadow-glow-green">
+                  ✨ Optimisé
+                </Badge>
+              )}
+            </div>
+
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-white hover:bg-white/10 rounded-full"
+            >
+              <Share2 className="w-6 h-6" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/hooks/useMediaFeed.ts
+++ b/frontend/src/hooks/useMediaFeed.ts
@@ -1,0 +1,46 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useInView } from "react-intersection-observer";
+import { useEffect } from "react";
+import { getMediaFeed } from "@/services/api";
+
+export function useMediaFeed() {
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    error,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: ["media-feed"],
+    queryFn: async ({ pageParam }) => {
+      // getMediaFeed returns { items, nextCursor }
+      return getMediaFeed(pageParam as string | undefined);
+    },
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    initialPageParam: undefined as string | undefined,
+  });
+
+  const { ref, inView } = useInView({
+    threshold: 0.1,
+    rootMargin: "400px",
+  });
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const items = data?.pages.flatMap((page) => page.items) ?? [];
+
+  return {
+    items,
+    loadMoreRef: ref,
+    isLoading,
+    isFetchingNextPage,
+    error,
+    refetch,
+  };
+}

--- a/frontend/src/pages/Feed.tsx
+++ b/frontend/src/pages/Feed.tsx
@@ -11,7 +11,7 @@ import { GiftModal } from "@/components/features/GiftModal";
 import { GiftOverlay } from "@/components/features/GiftOverlay";
 import { Onboarding, useOnboarding } from "@/components/Onboarding";
 import { getCurrentUser, getStories } from "@/services/api";
-import { ContinuousFeed } from "@/components/features/ContinuousFeed";
+import { MediaFeed } from "@/components/media/MediaFeed";
 import { ErrorBoundary, ErrorFallback } from "@/components/ErrorBoundary";
 import { AvatarSkeleton } from "@/components/ui/Skeleton";
 
@@ -210,12 +210,12 @@ export const Feed: React.FC = () => {
         <div className="absolute bottom-0 left-0 right-0 h-[1px] bg-gold-500/20" />
       </div>
 
-      {/* Main Content - Continuous Video Feed */}
-      <div className="flex-1 w-full bg-black relative">
+      {/* Main Content - Media Feed */}
+      <div className="flex-1 w-full bg-black relative overflow-y-auto no-scrollbar scroll-smooth">
         <ErrorBoundary
           fallback={<ErrorFallback onRetry={() => window.location.reload()} />}
         >
-          <ContinuousFeed />
+          <MediaFeed />
         </ErrorBoundary>
       </div>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -96,3 +96,18 @@ export type ButtonSize = "sm" | "md" | "lg";
 export type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl";
 
 export type ToastType = "success" | "error" | "info" | "warning";
+
+export interface Media {
+  id: string;
+  userId: string;
+  type: "IMAGE" | "VIDEO";
+  muxAssetId?: string | null;
+  supabaseUrl?: string | null;
+  thumbnailUrl: string;
+  caption?: string | null;
+  enhancedUrl?: string | null;
+  enhanceStatus: "PENDING" | "PROCESSING" | "DONE" | "FAILED";
+  enhancedAt?: string | null;
+  createdAt: string;
+  user?: User;
+}

--- a/infrastructure/colony/core/task_poller.py
+++ b/infrastructure/colony/core/task_poller.py
@@ -2,6 +2,13 @@
 Task Poller - The Hive Mind 🐝
 Central task routing and state machine for Colony OS.
 
+TODO: The 'upscale_video' task is now handled by the Node.js worker via BullMQ.
+This poller is only responsible for:
+- Security checks
+- Health checks
+- Text generation (DeepSeek)
+- Legacy Python-based tasks
+
 Hardened version with:
 - Heartbeat updates for stuck task detection
 - Automatic stuck task recovery

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "@types/bcryptjs": "^2.4.6",
         "@types/dompurify": "^3.0.5",
         "@types/memoizee": "^0.4.12",
-        "@upstash/redis": "^1.36.0",
         "@vercel/otel": "^2.1.0",
         "ai": "^5.0.112",
         "axios": "^1.13.2",
@@ -109,6 +108,7 @@
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@types/socket.io-client": "^3.0.0",
+        "@types/supertest": "^6.0.3",
         "@types/uuid": "^11.0.0",
         "@types/ws": "^8.5.13",
         "@typescript-eslint/eslint-plugin": "^8.50.1",
@@ -129,6 +129,7 @@
         "lint-staged": "^15.2.0",
         "postcss": "^8.5.6",
         "prettier": "^3.0.0",
+        "supertest": "^7.1.4",
         "tailwindcss": "^4.1.14",
         "turbo": "latest",
         "typescript": "5.6.3",
@@ -2473,6 +2474,19 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3767,6 +3781,16 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -6672,6 +6696,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -6811,6 +6842,13 @@
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.12.tgz",
       "integrity": "sha512-EdtpwNYNhe3kZ+4TlXj/++pvBoU0KdrAICMzgI7vjWgu9sIvvUhu9XR8Ks4L6Wh3sxpZ22wkZR7yCLAqUjnZuQ=="
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mysql": {
       "version": "2.15.27",
@@ -6961,6 +6999,30 @@
       "dev": true,
       "dependencies": {
         "socket.io-client": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@types/tedious": {
@@ -7238,14 +7300,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true
-    },
-    "node_modules/@upstash/redis": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.0.tgz",
-      "integrity": "sha512-9zN2UV9QJGPnXfWU3yZBLVQaqqENDh7g+Y4J2vJuSxBCi9FQ0aUOtaXlzuFhnsiZvCqM+eS27ic+tgmkWUsfOg==",
-      "dependencies": {
-        "uncrypto": "^0.1.3"
-      }
     },
     "node_modules/@vercel/oidc": {
       "version": "3.0.5",
@@ -7784,6 +7838,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -8379,6 +8440,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8422,6 +8493,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cron-parser": {
       "version": "4.9.0",
@@ -8849,6 +8927,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -9991,6 +10080,13 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
@@ -10257,6 +10353,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -15251,6 +15365,54 @@
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -15838,11 +16000,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/uncrypto": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -18093,6 +18250,12 @@
         }
       }
     },
+    "@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -18928,6 +19091,15 @@
       "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
       "requires": {
         "@opentelemetry/core": "^2.0.0"
+      }
+    },
+    "@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "requires": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "@pkgjs/parseargs": {
@@ -20523,6 +20695,12 @@
         "@types/node": "*"
       }
     },
+    "@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true
+    },
     "@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -20661,6 +20839,12 @@
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.12.tgz",
       "integrity": "sha512-EdtpwNYNhe3kZ+4TlXj/++pvBoU0KdrAICMzgI7vjWgu9sIvvUhu9XR8Ks4L6Wh3sxpZ22wkZR7yCLAqUjnZuQ=="
+    },
+    "@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true
     },
     "@types/mysql": {
       "version": "2.15.27",
@@ -20807,6 +20991,28 @@
       "dev": true,
       "requires": {
         "socket.io-client": "*"
+      }
+    },
+    "@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "requires": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "requires": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "@types/tedious": {
@@ -20984,14 +21190,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true
-    },
-    "@upstash/redis": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.36.0.tgz",
-      "integrity": "sha512-9zN2UV9QJGPnXfWU3yZBLVQaqqENDh7g+Y4J2vJuSxBCi9FQ0aUOtaXlzuFhnsiZvCqM+eS27ic+tgmkWUsfOg==",
-      "requires": {
-        "uncrypto": "^0.1.3"
-      }
     },
     "@vercel/oidc": {
       "version": "3.0.5",
@@ -21360,6 +21558,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
     },
     "assertion-error": {
       "version": "2.0.1",
@@ -21776,6 +21980,12 @@
       "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "dev": true
     },
+    "component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -21810,6 +22020,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+    },
+    "cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "cron-parser": {
       "version": "4.9.0",
@@ -22111,6 +22327,16 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
+    "dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "doctrine": {
       "version": "3.0.0",
@@ -22927,6 +23153,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "fast-xml-parser": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
@@ -23114,6 +23346,17 @@
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "requires": {
         "fetch-blob": "^3.1.2"
+      }
+    },
+    "formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "requires": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
       }
     },
     "forwarded": {
@@ -26509,6 +26752,41 @@
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
+    "superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+          "dev": true
+        }
+      }
+    },
+    "supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      }
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -26904,11 +27182,6 @@
         "has-symbols": "^1.1.0",
         "which-boxed-primitive": "^1.1.1"
       }
-    },
-    "uncrypto": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
     },
     "undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -123,13 +123,13 @@
     "stripe": "^20.0.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
+    "tsx": "^4.20.5",
     "tw-animate-css": "^1.4.0",
     "uuid": "^13.0.0",
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.25.76",
-    "zod-validation-error": "^3.4.0",
-    "tsx": "^4.20.5"
+    "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",
@@ -144,6 +144,7 @@
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@types/socket.io-client": "^3.0.0",
+    "@types/supertest": "^6.0.3",
     "@types/uuid": "^11.0.0",
     "@types/ws": "^8.5.13",
     "@typescript-eslint/eslint-plugin": "^8.50.1",
@@ -164,6 +165,7 @@
     "lint-staged": "^15.2.0",
     "postcss": "^8.5.6",
     "prettier": "^3.0.0",
+    "supertest": "^7.1.4",
     "tailwindcss": "^4.1.14",
     "turbo": "latest",
     "typescript": "5.6.3",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -47,6 +47,12 @@ export const vector = customType<{
 // Enums
 export const visibilityEnum = pgEnum("visibility", ["public", "amis", "prive"]);
 export const mediaTypeEnum = pgEnum("media_type", ["IMAGE", "VIDEO"]);
+export const enhanceStatusEnum = pgEnum("enhance_status", [
+  "PENDING",
+  "PROCESSING",
+  "DONE",
+  "FAILED",
+]);
 export const regionEnum = pgEnum("region", [
   "montreal",
   "quebec",
@@ -128,6 +134,9 @@ export const media = pgTable(
     supabaseUrl: text("supabase_url"), // For images or legacy videos
     thumbnailUrl: text("thumbnail_url").notNull(),
     caption: text("caption"),
+    enhancedUrl: text("enhanced_url"),
+    enhanceStatus: enhanceStatusEnum("enhance_status").default("PENDING"),
+    enhancedAt: timestamp("enhanced_at"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (table) => ({
@@ -239,9 +248,15 @@ export const posts = pgTable(
     aiLabels: jsonb("ai_labels").default([]), // AI generated tags
     contentFr: text("content_fr"),
     contentEn: text("content_en"),
-    hashtags: text("hashtags").array().default(sql`'{}'::text[]`),
-    detectedThemes: text("detected_themes").array().default(sql`'{}'::text[]`),
-    detectedItems: text("detected_items").array().default(sql`'{}'::text[]`),
+    hashtags: text("hashtags")
+      .array()
+      .default(sql`'{}'::text[]`),
+    detectedThemes: text("detected_themes")
+      .array()
+      .default(sql`'{}'::text[]`),
+    detectedItems: text("detected_items")
+      .array()
+      .default(sql`'{}'::text[]`),
     aiGenerated: boolean("ai_generated").default(false),
     viralScore: integer("viral_score").default(0), // Le Buzz Predictor
     safetyFlags: jsonb("safety_flags").default({}), // Safety Patrol details


### PR DESCRIPTION
## Description

This PR establishes the foundational backend and database structure for a unified media feed. It introduces a new `Media` data model, API endpoints (`/api/media`) for managing media items, and integrates existing upload flows (Mux for video, Supabase for images) to automatically populate this feed. This lays the groundwork for a continuous scroll UI on the frontend.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting (no functional changes)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test updates
- [ ] 🔧 Configuration changes
- [ ] 🔒 Security fix

## Related Issues

Fixes #
Related to #

## Changes Made

-   **Database Schema**: Added `media` table (Drizzle ORM) to `shared/schema.ts` with `id`, `userId`, `type` (IMAGE/VIDEO), `muxAssetId`, `supabaseUrl`, `thumbnailUrl`, `caption`, and `createdAt` (indexed).
-   **API Endpoints**: Created `backend/routes/media.ts` with:
    -   `POST /api/media`: Creates a new media entry with Zod validation.
    -   `GET /api/media`: Provides a paginated, reverse-chronological feed.
    -   `GET /api/media/:id`: Fetches a single media item.
-   **Upload Integration**:
    -   Mux webhook handler (`backend/routes/mux.ts`) now creates `Media` entries for ready videos.
    -   Image upload handler (`backend/routes.ts`) creates `Media` entries for successful image uploads.
-   **Storage Layer**: Added `createMedia`, `getMedia`, and `getMediaFeed` methods to `backend/storage.ts`.
-   **Routing**: Registered the new `mediaRouter` in `backend/index.ts`.

## Screenshots (if applicable)

## Testing Checklist

- [x] I have tested these changes locally
- [x] All existing tests pass (`npm test`) - *No new tests added for this feature, existing tests pass.*
- [ ] I have added tests for new functionality - *No new tests added in this phase.*
- [x] TypeScript compilation succeeds (`npm run check`)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)

## Code Quality Checklist

- [x] Code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented complex or non-obvious code
- [ ] I have updated documentation as needed - *README/CHANGELOG not updated in this phase.*
- [x] My changes generate no new warnings or errors
- [x] I have checked for and eliminated `any` types where possible

## Accessibility Checklist (for UI changes)

- [ ] Keyboard navigation tested
- [ ] Screen reader tested (NVDA/VoiceOver)
- [ ] Color contrast meets WCAG 2.1 AA standards (4.5:1 minimum)
- [ ] Focus indicators are visible
- [ ] Semantic HTML used appropriately
- [ ] ARIA attributes added where necessary

## Security Checklist

- [x] No sensitive data (API keys, passwords, tokens) in code
- [x] Input validation implemented where needed - *Zod validation used for POST /api/media.*
- [ ] SQL injection prevention verified (parameterized queries) - *Drizzle ORM handles this.*
- [ ] XSS prevention verified (sanitized outputs) - *N/A for backend data.*
- [ ] CSRF protection maintained - *N/A for API.*
- [ ] Authentication/authorization checks in place - *`userId` is currently derived from `req.userId` or passed in body; full auth not implemented in this phase.*

## Deployment Checklist

- [ ] Environment variables documented (if new ones added)
- [ ] Database migrations included (if schema changed) - *Migration file `MIGRATION_PENDING.md` generated, but needs manual push.*
- [ ] README updated (if setup/deployment process changed)
- [ ] CHANGELOG.md updated
- [ ] No breaking changes to existing APIs (or documented if unavoidable)

## Vercel Preview Deployment

- [ ] Preview deployment successful
- [ ] Preview tested manually

## Additional Notes

-   **Database Migration Required**: The schema has been updated. Please run `npm run db:push` or `npx drizzle-kit push` to apply the new `media` table and `media_type` enum to your database.
-   **`userId` Placeholder**: For `POST /api/media`, `userId` is expected in the request body. For Mux and image uploads, it's derived from `updatedPost.userId` or `req.userId`. A more robust authentication system would typically provide this from the request context.
-   **Thumbnail URL Strategy**: For images, `thumbnailUrl` currently defaults to `supabaseUrl`. Mux handles video thumbnail generation.

## Pre-commit Hooks

- [x] Pre-commit hooks passed (lint-staged)

---
<a href="https://cursor.com/background-agent?bcId=bc-992af339-59fe-4ce9-b5ff-acdb79d703ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-992af339-59fe-4ce9-b5ff-acdb79d703ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes a backend foundation for a unified media feed with DB, API, and ingestion hooks.
> 
> - **Database**: Adds `media_type` enum and `media` table (`id`, `userId`, `type`, `muxAssetId`, `supabaseUrl`, `thumbnailUrl`, `caption`, `createdAt`), plus indexes and types in `shared/schema.ts`
> - **API**: New `backend/routes/media.ts` with `POST /api/media` (Zod-validated create), `GET /api/media` (cursor pagination), and `GET /api/media/:id`; router registered in `backend/index.ts`
> - **Storage layer**: Implements `createMedia`, `getMedia`, `getMediaFeed` in `backend/storage.ts` with cursor-based pagination
> - **Ingestion**: 
>   - On post create (images), immediately `createMedia` if no `mux*` IDs (`backend/routes.ts`)
>   - On Mux `video.asset.ready`, update post then `createMedia` for videos (`backend/routes/mux.ts`)
> - **Migration note**: Adds `MIGRATION_PENDING.md` with instructions to push schema changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39bd12e9d0e756dc67e9eb46c0ae055021b0f83c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->