### PR TITLE
fix(security): RLS on production tables, upload auth, socket auth, webhook hardening

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -13,8 +13,11 @@ if (
 }
 import express from "express";
 import cors from "cors";
+import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import { registerRoutes } from "./routes.js";
+import { verifyAuthToken } from "./supabase-auth.js";
+import { storage } from "./storage.js";
 import { recoverBotMatches } from "./services/grid-rush-service.js";
 import { serveStatic } from "./static.js";
 import tiGuyRouter from "./routes/tiguy.js";
@@ -80,6 +83,21 @@ app.use(
 
 // Handle OPTIONS preflight for all routes - use regex pattern to avoid path-to-regexp issues
 app.options(/.*/, cors());
+
+// helmet: baseline security headers (nosniff, HSTS, frameguard, etc.).
+// CSP is disabled because the API serves cross-origin JSON to the Vercel SPA and
+// a restrictive default policy would break it; the explicit headers below keep
+// the previously-set behavior (notably X-Frame-Options: DENY).
+app.use(
+  helmet({
+    contentSecurityPolicy: false,
+    hsts: {
+      maxAge: 63072000,
+      includeSubDomains: true,
+      preload: true,
+    },
+  }),
+);
 
 // Security Headers Middleware
 app.use((req, res, next) => {
@@ -195,8 +213,48 @@ const io = new SocketIOServer(httpServer, {
 
 app.set("io", io);
 
+// Authenticate every socket at the handshake. The Supabase JWT may arrive via
+// auth.token (preferred), the Authorization header, or a query param. We derive
+// userId server-side from the verified token and never trust client-supplied
+// identity on subsequent events. See audit §2/§5.2.
+io.use(async (socket, next) => {
+  try {
+    const auth = (socket.handshake.auth || {}) as { token?: string };
+    const headerAuth = socket.handshake.headers?.authorization;
+    const queryToken = socket.handshake.query?.token;
+    let token: string | undefined = auth.token;
+    if (!token && typeof headerAuth === "string" && headerAuth.startsWith("Bearer ")) {
+      token = headerAuth.slice("Bearer ".length).trim();
+    }
+    if (!token && typeof queryToken === "string") {
+      token = queryToken;
+    }
+    if (!token) {
+      return next(new Error("Unauthorized: missing token"));
+    }
+    const userId = await verifyAuthToken(token);
+    if (!userId) {
+      return next(new Error("Unauthorized: invalid token"));
+    }
+    (socket.data as { userId?: string }).userId = userId;
+    return next();
+  } catch (err) {
+    return next(new Error("Unauthorized"));
+  }
+});
+
+// Strip HTML-significant characters so chat text can never be rendered as markup.
+function sanitizeChatText(input: unknown): string {
+  if (typeof input !== "string") return "";
+  return input
+    .replace(/[<>]/g, "")
+    .slice(0, 200)
+    .trim();
+}
+
 io.on("connection", (socket) => {
-  console.log("🔌 Socket.IO Client Connected:", socket.id);
+  const socketUserId = (socket.data as { userId?: string }).userId;
+  console.log("🔌 Socket.IO Client Connected:", socket.id, socketUserId);
 
   // ─── LIVE CHAT ────────────────────────────────────────────────────────────
   // Join a live stream room to receive/send chat messages
@@ -227,24 +285,40 @@ io.on("connection", (socket) => {
     io.to(room).emit("live:viewer_count", { count });
   });
 
-  // Chat message in a live room
-  socket.on(
-    "live:message",
-    ({ streamId, userId, username, avatarUrl, text, tier }: any) => {
-      if (!streamId || !text?.trim()) return;
-      const room = `live:${streamId}`;
-      const message = {
-        id: `${Date.now()}-${socket.id}`,
-        userId,
-        username: username || "Anonyme",
-        avatarUrl,
-        text: text.slice(0, 200),
-        tier: tier || "free", // bronze/silver/gold — used for coloured name
-        timestamp: Date.now(),
-      };
-      io.to(room).emit("live:message", message);
-    },
-  );
+  // Chat message in a live room. Identity is resolved server-side from the
+  // verified socket userId — client-supplied userId/username/tier/avatarUrl are
+  // ignored to prevent impersonation, and text is HTML-stripped + length-capped.
+  socket.on("live:message", async ({ streamId, text }: any) => {
+    if (!streamId || !socketUserId) return;
+    const cleanText = sanitizeChatText(text);
+    if (!cleanText) return;
+    const room = `live:${streamId}`;
+
+    let username = "Anonyme";
+    let avatarUrl: string | null | undefined;
+    let tier = "free";
+    try {
+      const user = await storage.getUser(socketUserId);
+      if (user) {
+        username = user.username || username;
+        avatarUrl = user.avatarUrl;
+        tier = user.subscriptionTier || tier;
+      }
+    } catch (err) {
+      console.warn("[Live] failed to resolve user for chat message:", err);
+    }
+
+    const message = {
+      id: `${Date.now()}-${socket.id}`,
+      userId: socketUserId,
+      username,
+      avatarUrl,
+      text: cleanText,
+      tier, // bronze/silver/gold — used for coloured name
+      timestamp: Date.now(),
+    };
+    io.to(room).emit("live:message", message);
+  });
 
   // Gift sent during a live
   socket.on(

--- a/backend/middleware/seed-auth.ts
+++ b/backend/middleware/seed-auth.ts
@@ -4,6 +4,7 @@
 import type { Request, Response, NextFunction } from "express";
 import { verifyAuthToken } from "../supabase-auth.js";
 import { storage } from "../storage.js";
+import { timingSafeEqualStr } from "../utils/timing-safe-equal.js";
 
 /** Strip whitespace and optional wrapping quotes from Render/env paste. */
 export function normalizeCronSecret(raw: string | undefined): string {
@@ -34,7 +35,7 @@ export async function requireSeedAccess(
   const cronSecret = normalizeCronSecret(process.env.CRON_SECRET);
   const header = cronHeader(req);
 
-  if (cronSecret && header === cronSecret) {
+  if (cronSecret && timingSafeEqualStr(header, cronSecret)) {
     return next();
   }
 
@@ -65,12 +66,8 @@ export async function requireSeedAccess(
 
   res.status(401).json({
     error: "Unauthorized",
-    ...(header
-      ? {
-          hint: "X-Cron-Secret mismatch — redeploy after updating Render env",
-          expectedLen: cronSecret.length,
-          gotLen: header.length,
-        }
-      : { hint: "Missing X-Cron-Secret header" }),
+    hint: header
+      ? "X-Cron-Secret mismatch — redeploy after updating Render env"
+      : "Missing X-Cron-Secret header",
   });
 }

--- a/backend/routes.ts
+++ b/backend/routes.ts
@@ -13,6 +13,7 @@ declare global {
 import { storage } from "./storage.js";
 // [NEW] Import the JWT verifier + Supabase admin client (for auto-provisioning)
 import { verifyAuthToken } from "./supabase-auth.js";
+import { timingSafeEqualStr } from "./utils/timing-safe-equal.js";
 import aiRoutes from "./routes/ai.routes.js";
 
 import adminRoutes from "./routes/admin.js";
@@ -147,7 +148,7 @@ export async function registerRoutes(
     if (!expected) {
       return res.status(503).json({ error: "WEBHOOK_SECRET not configured" });
     }
-    if (secret !== expected) {
+    if (!timingSafeEqualStr(secret, expected)) {
       return res.status(401).json({ error: "Invalid webhook secret" });
     }
     const { videoId } = req.body || {};
@@ -166,7 +167,7 @@ export async function registerRoutes(
       return res.status(500).json({ error: "HIVE_SECRET_KEY not configured" });
     }
 
-    if (secret !== expected) {
+    if (!timingSafeEqualStr(secret, expected)) {
       return res.status(401).json({ error: "Hive Secret Invalid" });
     }
 

--- a/backend/routes/upload-surgical.ts
+++ b/backend/routes/upload-surgical.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from "express";
 import { storage } from "../storage.js";
 import { createClient } from "@supabase/supabase-js";
 import multer from "multer";
-import { verifyAuthToken } from "../supabase-auth.js";
+import { requireAuth } from "../supabase-auth.js";
 import crypto from "crypto";
 import { inferMediaType } from "../../shared/utils/validatePostType.js";
 
@@ -33,6 +33,7 @@ if (SUPABASE_URL && SUPABASE_SERVICE_KEY) {
  */
 surgicalUploadRouter.post(
   "/simple",
+  requireAuth,
   upload.single("video"),
   async (req: Request, res: Response) => {
     try {
@@ -45,18 +46,9 @@ surgicalUploadRouter.post(
         });
       }
 
-      // 1. Authenticate
-      let userId: string | null = null;
-      const authHeader = req.headers.authorization;
-      if (authHeader?.startsWith("Bearer ")) {
-        userId = await verifyAuthToken(authHeader.split(" ")[1]);
-      }
-
-      if (!userId) {
-        // Allow explicit userId in body for testing only
-        userId = req.body.userId || null;
-      }
-
+      // Identity comes from the verified bearer token (requireAuth). Never trust
+      // a client-supplied userId — see audit §2.2 (upload IDOR / impersonation).
+      const userId = (req as Request & { userId?: string }).userId;
       if (!userId)
         return res.status(401).json({ error: "Unauthorized credentials" });
 
@@ -73,7 +65,7 @@ surgicalUploadRouter.post(
         .from("zyeute-videos")
         .upload(fileName, buffer, {
           contentType: mimetype,
-          upsert: true,
+          upsert: false,
         });
 
       if (uploadError) {

--- a/backend/utils/timing-safe-equal.ts
+++ b/backend/utils/timing-safe-equal.ts
@@ -1,0 +1,19 @@
+import crypto from "crypto";
+
+/**
+ * Constant-time comparison of two secret strings.
+ *
+ * crypto.timingSafeEqual throws on length mismatch and would itself leak length
+ * via the throw, so we hash both inputs to a fixed-width digest first. This keeps
+ * the comparison both constant-time AND length-safe — a mismatched length is
+ * indistinguishable from a mismatched value to the caller.
+ */
+export function timingSafeEqualStr(
+  a: string | string[] | undefined | null,
+  b: string | undefined | null,
+): boolean {
+  if (typeof a !== "string" || typeof b !== "string") return false;
+  const ah = crypto.createHash("sha256").update(a).digest();
+  const bh = crypto.createHash("sha256").update(b).digest();
+  return crypto.timingSafeEqual(ah, bh);
+}

--- a/migrations/0032_french_tables_rls.sql
+++ b/migrations/0032_french_tables_rls.sql
@@ -1,0 +1,165 @@
+-- Migration: RLS hardening on the ACTUAL French production tables
+-- Description: 0015_core_rls_hardening targeted English table names (posts/comments/
+--   follows/post_reactions) that were created by the base migration but are NOT the
+--   tables the live app queries. The app uses the French physical names defined in
+--   shared/schema.ts: publications, commentaires, reactions, abonnements, gifts.
+--   Those were created out-of-band (drizzle-kit push / manual SQL) and had RLS
+--   disabled (Postgres default = anon key can read/write every row).
+--
+--   This migration enables RLS + owner-scoped policies on the French tables.
+--   Every statement is guarded so it is safe to run regardless of which tables
+--   exist in a given environment, and re-runnable (DROP POLICY IF EXISTS first).
+--
+-- Physical column notes (from shared/schema.ts):
+--   publications.is_hidden  -> column "est_masque"
+--   abonnements.following_id -> column "followee_id"
+
+-- ─── 1. PUBLICATIONS (posts) ────────────────────────────────────────────────
+DO $$
+BEGIN
+  IF to_regclass('public.publications') IS NOT NULL THEN
+    ALTER TABLE public.publications ENABLE ROW LEVEL SECURITY;
+
+    DROP POLICY IF EXISTS "publications_public_read" ON public.publications;
+    CREATE POLICY "publications_public_read" ON public.publications
+      FOR SELECT TO authenticated, anon
+      USING (visibility = 'public' AND est_masque = false AND deleted_at IS NULL);
+
+    DROP POLICY IF EXISTS "publications_owner_insert" ON public.publications;
+    CREATE POLICY "publications_owner_insert" ON public.publications
+      FOR INSERT TO authenticated
+      WITH CHECK (user_id = auth.uid());
+
+    DROP POLICY IF EXISTS "publications_owner_update" ON public.publications;
+    CREATE POLICY "publications_owner_update" ON public.publications
+      FOR UPDATE TO authenticated
+      USING (user_id = auth.uid())
+      WITH CHECK (user_id = auth.uid());
+
+    DROP POLICY IF EXISTS "publications_owner_delete" ON public.publications;
+    CREATE POLICY "publications_owner_delete" ON public.publications
+      FOR DELETE TO authenticated
+      USING (user_id = auth.uid());
+  END IF;
+END $$;
+
+-- ─── 2. COMMENTAIRES (comments) ─────────────────────────────────────────────
+DO $$
+BEGIN
+  IF to_regclass('public.commentaires') IS NOT NULL THEN
+    ALTER TABLE public.commentaires ENABLE ROW LEVEL SECURITY;
+
+    DROP POLICY IF EXISTS "commentaires_read" ON public.commentaires;
+    CREATE POLICY "commentaires_read" ON public.commentaires
+      FOR SELECT TO authenticated
+      USING (true);
+
+    DROP POLICY IF EXISTS "commentaires_owner_insert" ON public.commentaires;
+    CREATE POLICY "commentaires_owner_insert" ON public.commentaires
+      FOR INSERT TO authenticated
+      WITH CHECK (user_id = auth.uid());
+
+    DROP POLICY IF EXISTS "commentaires_owner_update" ON public.commentaires;
+    CREATE POLICY "commentaires_owner_update" ON public.commentaires
+      FOR UPDATE TO authenticated
+      USING (user_id = auth.uid())
+      WITH CHECK (user_id = auth.uid());
+
+    DROP POLICY IF EXISTS "commentaires_owner_delete" ON public.commentaires;
+    CREATE POLICY "commentaires_owner_delete" ON public.commentaires
+      FOR DELETE TO authenticated
+      USING (user_id = auth.uid());
+  END IF;
+END $$;
+
+-- ─── 3. REACTIONS (postReactions) ───────────────────────────────────────────
+DO $$
+BEGIN
+  IF to_regclass('public.reactions') IS NOT NULL THEN
+    ALTER TABLE public.reactions ENABLE ROW LEVEL SECURITY;
+
+    DROP POLICY IF EXISTS "reactions_read" ON public.reactions;
+    CREATE POLICY "reactions_read" ON public.reactions
+      FOR SELECT TO authenticated
+      USING (true);
+
+    DROP POLICY IF EXISTS "reactions_owner_insert" ON public.reactions;
+    CREATE POLICY "reactions_owner_insert" ON public.reactions
+      FOR INSERT TO authenticated
+      WITH CHECK (user_id = auth.uid());
+
+    DROP POLICY IF EXISTS "reactions_owner_update" ON public.reactions;
+    CREATE POLICY "reactions_owner_update" ON public.reactions
+      FOR UPDATE TO authenticated
+      USING (user_id = auth.uid())
+      WITH CHECK (user_id = auth.uid());
+
+    DROP POLICY IF EXISTS "reactions_owner_delete" ON public.reactions;
+    CREATE POLICY "reactions_owner_delete" ON public.reactions
+      FOR DELETE TO authenticated
+      USING (user_id = auth.uid());
+  END IF;
+END $$;
+
+-- ─── 4. ABONNEMENTS (follows) ───────────────────────────────────────────────
+-- Owner is the follower (follower_id). Physical "following" column is "followee_id".
+DO $$
+BEGIN
+  IF to_regclass('public.abonnements') IS NOT NULL THEN
+    -- Dedupe any existing duplicate edges before adding the unique index.
+    DELETE FROM public.abonnements a
+    USING public.abonnements b
+    WHERE a.ctid < b.ctid
+      AND a.follower_id = b.follower_id
+      AND a.followee_id = b.followee_id;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS abonnements_follower_followee_uniq
+      ON public.abonnements (follower_id, followee_id);
+
+    ALTER TABLE public.abonnements ENABLE ROW LEVEL SECURITY;
+
+    DROP POLICY IF EXISTS "abonnements_read" ON public.abonnements;
+    CREATE POLICY "abonnements_read" ON public.abonnements
+      FOR SELECT TO authenticated
+      USING (true);
+
+    DROP POLICY IF EXISTS "abonnements_owner_insert" ON public.abonnements;
+    CREATE POLICY "abonnements_owner_insert" ON public.abonnements
+      FOR INSERT TO authenticated
+      WITH CHECK (follower_id = auth.uid());
+
+    DROP POLICY IF EXISTS "abonnements_owner_update" ON public.abonnements;
+    CREATE POLICY "abonnements_owner_update" ON public.abonnements
+      FOR UPDATE TO authenticated
+      USING (follower_id = auth.uid())
+      WITH CHECK (follower_id = auth.uid());
+
+    DROP POLICY IF EXISTS "abonnements_owner_delete" ON public.abonnements;
+    CREATE POLICY "abonnements_owner_delete" ON public.abonnements
+      FOR DELETE TO authenticated
+      USING (follower_id = auth.uid());
+  END IF;
+END $$;
+
+-- ─── 5. GIFTS (monetized ledger) ────────────────────────────────────────────
+-- SELECT only for the two parties to a gift. No client write access at all —
+-- gifts are written exclusively by the backend (service_role bypasses RLS).
+DO $$
+BEGIN
+  IF to_regclass('public.gifts') IS NOT NULL THEN
+    ALTER TABLE public.gifts ENABLE ROW LEVEL SECURITY;
+
+    DROP POLICY IF EXISTS "gifts_party_read" ON public.gifts;
+    CREATE POLICY "gifts_party_read" ON public.gifts
+      FOR SELECT TO authenticated
+      USING (sender_id = auth.uid() OR recipient_id = auth.uid());
+
+    -- Explicitly remove any client write policies. With RLS enabled and no
+    -- INSERT/UPDATE/DELETE policy, anon/authenticated cannot write — only
+    -- service_role (which bypasses RLS) can.
+    DROP POLICY IF EXISTS "gifts_owner_insert" ON public.gifts;
+    DROP POLICY IF EXISTS "gifts_owner_update" ON public.gifts;
+    DROP POLICY IF EXISTS "gifts_owner_delete" ON public.gifts;
+    DROP POLICY IF EXISTS "gifts_self_manage" ON public.gifts;
+  END IF;
+END $$;

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "fluent-ffmpeg": "^2.1.3",
         "framer-motion": "^12.34.0",
         "groq-sdk": "^0.37.0",
+        "helmet": "^8.1.0",
         "hls.js": "^1.6.15",
         "ioredis": "^5.9.2",
         "lucide-react": "^0.563.0",
@@ -15783,6 +15784,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/hermes-estree": {

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "fluent-ffmpeg": "^2.1.3",
     "framer-motion": "^12.34.0",
     "groq-sdk": "^0.37.0",
+    "helmet": "^8.1.0",
     "hls.js": "^1.6.15",
     "ioredis": "^5.9.2",
     "lucide-react": "^0.563.0",


### PR DESCRIPTION
## Summary

Implements the launch-blocking hotfixes from the 2026-06-11 security & data architecture audit (`audit/security_data.md`). Scope is deliberately surgical — no unrelated refactors.

### 1. RLS on the ACTUAL French production tables (audit §3.1, §3.2 — HIGH)
`migrations/0032_french_tables_rls.sql`. The prior `0015_core_rls_hardening.sql` enabled RLS on English table names (`posts`/`comments`/`follows`/`post_reactions`) that the app does **not** query. The live app uses the French physical names (per `shared/schema.ts`): `publications`, `commentaires`, `reactions`, `abonnements`, `gifts` — all of which had RLS disabled (anon key could read/write every row).

- **publications**: public `SELECT` only where `visibility='public' AND est_masque=false AND deleted_at IS NULL` (note: the physical `is_hidden` column is `est_masque`); owner-only `INSERT`/`UPDATE`/`DELETE` (`user_id = auth.uid()`).
- **commentaires / reactions**: authenticated read; owner-only writes (`user_id = auth.uid()`).
- **abonnements**: authenticated read; owner writes keyed on `follower_id = auth.uid()`. The physical "following" column is `followee_id`. Adds unique index `(follower_id, followee_id)` after `ctid`-based dedupe of existing duplicate edges.
- **gifts**: `SELECT` only when `sender_id = auth.uid() OR recipient_id = auth.uid()`; **no** client INSERT/UPDATE/DELETE policy (service_role only).
- Every block is idempotent: `to_regclass(...) IS NOT NULL` guards (tables created out-of-band) + `DROP POLICY IF EXISTS` + `CREATE INDEX IF NOT EXISTS`.

### 2. Upload IDOR (audit §2.2 — HIGH)
`backend/routes/upload-surgical.ts`: removed the `userId = req.body.userId` fallback that allowed unauthenticated impersonation. The `/simple` route now uses the shared `requireAuth` middleware and derives `userId` from the verified bearer token. Storage upload changed to `upsert:false` (audit §4).

### 3. Socket.IO auth (audit §4, §5.2 — HIGH)
`backend/index.ts`: added an `io.use()` handshake middleware that verifies the Supabase JWT (via `verifyAuthToken`, accepting `auth.token` / `Authorization` header / query param) and stores the verified `userId` on the socket. `live:message` now ignores client-supplied `userId`/`username`/`tier`/`avatarUrl`, resolves them from the DB by the verified `userId`, and strips `<`/`>` plus length-caps the text.

### 4. Webhook hardening (audit §6 — MED)
- `backend/utils/timing-safe-equal.ts`: new `timingSafeEqualStr` (SHA-256 then `crypto.timingSafeEqual` — constant-time AND length-safe).
- `backend/routes.ts`: hive (`/api/hive/event`) and video-processed webhook secret comparisons now use it instead of `!==`.
- `backend/middleware/seed-auth.ts`: cron-secret comparison uses it; removed the `expectedLen`/`gotLen` leak from the 401 response.

### 5. helmet (audit §5.5 — LOW)
`backend/index.ts`: added `helmet()` (added `helmet@^8.1.0` to deps). `contentSecurityPolicy: false` (cross-origin JSON API to the Vercel SPA would break under a default CSP); HSTS configured; existing manual `X-Frame-Options: DENY` / nosniff headers preserved.

## Testing

- `npm run check` (tsc): the repo's committed `tsconfig.json` pins `ignoreDeprecations: "6.0"` while TS 5.9.3 is installed, so `tsc` fails on a **pre-existing** config error unrelated to this PR. Verified by temporarily setting `"5.0"` and diffing: the 5 remaining type errors are identical on `main` and this branch — **this PR adds zero new type errors**, and none of the touched files report errors.
- Backend tests: `npx vitest run --config vitest.backend.config.ts` → **3 files / 22 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)