### PR TITLE
fix(core-loop): comments, onboarding completion, create route, profile loading, session persistence

### DIFF
--- a/backend/routes/__tests__/comments.test.ts
+++ b/backend/routes/__tests__/comments.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import type { Server } from "http";
+
+// --- Supabase REST mock ----------------------------------------------------
+// The posts router builds a Supabase client at import time, so we must mock
+// `@supabase/supabase-js` BEFORE importing the router and provide the env vars
+// that gate `supabaseRest`.
+process.env.VITE_SUPABASE_URL = "https://example.supabase.co";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
+
+const insertedRows: any[] = [];
+
+function makeQuery(table: string) {
+  // Chainable query builder that mimics the subset of supabase-js used by the
+  // comment routes: insert().select().single(), select().eq().single(), etc.
+  const ctx: { table: string; pendingInsert?: any } = { table };
+  const builder: any = {
+    insert(values: any) {
+      ctx.pendingInsert = values;
+      return builder;
+    },
+    select() {
+      return builder;
+    },
+    eq() {
+      return builder;
+    },
+    is() {
+      return builder;
+    },
+    in() {
+      return builder;
+    },
+    order() {
+      return Promise.resolve({ data: [], error: null });
+    },
+    async single() {
+      if (ctx.table === "commentaires" && ctx.pendingInsert) {
+        const row = {
+          id: "comment-1",
+          publication_id: ctx.pendingInsert.publication_id,
+          user_id: ctx.pendingInsert.user_id,
+          content: ctx.pendingInsert.content,
+          created_at: "2026-06-11T00:00:00.000Z",
+        };
+        insertedRows.push(row);
+        return { data: row, error: null };
+      }
+      if (ctx.table === "user_profiles") {
+        return {
+          data: {
+            id: "user-1",
+            username: "ti_guy",
+            display_name: "Ti-Guy",
+            avatar_url: null,
+            username_color: "#FFFFFF",
+          },
+          error: null,
+        };
+      }
+      if (ctx.table === "publications") {
+        return { data: { user_id: "author-1" }, error: null };
+      }
+      return { data: null, error: null };
+    },
+  };
+  return builder;
+}
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => ({
+    from: (table: string) => makeQuery(table),
+  }),
+}));
+
+// Avoid pulling real Redis/queue + notification side-effects.
+vi.mock("../../queue.js", () => ({
+  getModerationQueue: () => ({ add: vi.fn().mockResolvedValue(undefined) }),
+  getVideoQueue: () => ({ add: vi.fn() }),
+  getHLSVideoQueue: () => ({ add: vi.fn() }),
+}));
+vi.mock("../../services/pushNotify.js", () => ({
+  notifyNewComment: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("POST /api/posts/:id/comments", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const express = (await import("express")).default;
+    const postsRoutes = (await import("../posts.js")).default;
+
+    const app = express();
+    app.use(express.json());
+    // Simulate attachBearerUserId having verified a JWT.
+    app.use((req, _res, next) => {
+      (req as any).userId = "user-1";
+      next();
+    });
+    app.use("/api", postsRoutes);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("persists a comment and returns it with snake+camel fields", async () => {
+    const res = await fetch(`${baseUrl}/api/posts/post-123/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "Allô la gang!" }),
+    });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.comment).toBeTruthy();
+    expect(json.comment.content).toBe("Allô la gang!");
+    // Persisted against the correct FK columns
+    expect(insertedRows[0].publication_id).toBe("post-123");
+    expect(insertedRows[0].user_id).toBe("user-1");
+    // Response carries both naming conventions so any client mapping works
+    expect(json.comment.postId).toBe("post-123");
+    expect(json.comment.publication_id).toBe("post-123");
+    expect(json.comment.userId).toBe("user-1");
+    expect(json.comment.created_at).toBeTruthy();
+    expect(json.comment.createdAt).toBeTruthy();
+    expect(json.comment.user?.username).toBe("ti_guy");
+  });
+
+  it("rejects empty content with 400", async () => {
+    const res = await fetch(`${baseUrl}/api/posts/post-123/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "   " }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/routes/posts.ts
+++ b/backend/routes/posts.ts
@@ -690,9 +690,13 @@ router.post(
       const comment = {
         id: commentData.id,
         postId: commentData.publication_id,
+        // Dual snake/camel so any frontend consumer can read either field.
+        publication_id: commentData.publication_id,
         userId: commentData.user_id,
+        user_id: commentData.user_id,
         content: commentData.content,
         created_at: commentData.created_at,
+        createdAt: commentData.created_at,
       };
       // If user profile fetch failed, return a minimal stub so the frontend
       // can at least display something instead of falling back to "Utilisateur".
@@ -704,44 +708,55 @@ router.post(
         username_color: "#FFFFFF",
       };
 
-      // Fire-and-forget push notification for new comment
-      try {
-        const { data: pubData } = await supabaseRest!
-          .from("publications")
-          .select("user_id")
-          .eq("id", req.params.id)
-          .single();
-        const postAuthorId = pubData?.user_id;
-        const commenterUsername = (user as any)?.username || "";
-        const postId = req.params.id as string;
-        if (postAuthorId && postAuthorId !== req.userId && commenterUsername) {
-          const { notifyNewComment } =
-            await import("../services/pushNotify.js");
-          notifyNewComment(postAuthorId, commenterUsername, postId).catch(
-            () => {},
-          );
-        }
-      } catch (_e) {
-        /* non-critical */
-      }
-
-      // Fire-and-forget moderation check
-      try {
-        const { getModerationQueue } = await import("../queue.js");
-        const moderationQueue = getModerationQueue();
-        await moderationQueue.add("moderate-comment", {
-          contentType: "comment",
-          contentId: comment.id,
-          userId: req.userId!,
-          text: req.body.content,
-        });
-      } catch (modErr: any) {
-        console.warn("[Moderation] Comment queue failed:", modErr.message);
-      }
-
+      // Respond immediately — the comment is persisted. Notification and
+      // moderation are non-critical side-effects and must never block (or fail)
+      // the response, otherwise a slow Redis/queue makes the client time out
+      // and surface "Impossible d'envoyer le commentaire" for a saved comment.
       res.status(201).json({
         comment: { ...comment, user, isFired: false },
       });
+
+      // Push notification for new comment (best-effort, after response)
+      void (async () => {
+        try {
+          const { data: pubData } = await supabaseRest!
+            .from("publications")
+            .select("user_id")
+            .eq("id", req.params.id)
+            .single();
+          const postAuthorId = pubData?.user_id;
+          const commenterUsername = (user as any)?.username || "";
+          const postId = req.params.id as string;
+          if (
+            postAuthorId &&
+            postAuthorId !== req.userId &&
+            commenterUsername
+          ) {
+            const { notifyNewComment } =
+              await import("../services/pushNotify.js");
+            await notifyNewComment(postAuthorId, commenterUsername, postId);
+          }
+        } catch {
+          /* non-critical */
+        }
+      })();
+
+      // Moderation check (best-effort, after response)
+      void (async () => {
+        try {
+          const { getModerationQueue } = await import("../queue.js");
+          const moderationQueue = getModerationQueue();
+          await moderationQueue.add("moderate-comment", {
+            contentType: "comment",
+            contentId: comment.id,
+            userId: req.userId!,
+            text: content,
+          });
+        } catch (modErr: any) {
+          console.warn("[Moderation] Comment queue failed:", modErr?.message);
+        }
+      })();
+      return;
     } catch (error) {
       console.error("Create comment error:", error);
       res.status(500).json({ error: "Failed to create comment" });

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,27 @@
+/**
+ * 404 — Page introuvable (French).
+ * Replaces the silent redirect-to-feed on unknown routes.
+ */
+
+import { Link } from "react-router-dom";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-black leather-overlay flex items-center justify-center px-4">
+      <div className="text-center">
+        <div className="text-7xl mb-4">⚜️</div>
+        <h1 className="text-5xl font-black text-gold-500 mb-2">404</h1>
+        <h2 className="text-xl font-bold text-white mb-3">Page introuvable</h2>
+        <p className="text-gray-400 mb-8 max-w-sm mx-auto">
+          Oups! Cette page n'existe pas ou a été déplacée.
+        </p>
+        <Link
+          to="/feed"
+          className="inline-block px-6 py-3 rounded-xl font-bold text-black bg-gradient-to-br from-gold-400 to-gold-600 hover:opacity-90 transition"
+        >
+          Retour au fil
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -31,7 +31,7 @@ const INTERESTS = [
   { emoji: "🏔️", label: "Nature" },
   { emoji: "✨", label: "Mode" },
   { emoji: "📱", label: "Tech" },
-  { emoji: "🌙", label: "Nightlife" },
+  { emoji: "🌙", label: "Vie nocturne" },
   { emoji: "🎨", label: "Art" },
   { emoji: "🎮", label: "Gaming" },
   { emoji: "🎭", label: "Arts & spectacles" },
@@ -193,12 +193,15 @@ export const Onboarding: React.FC<OnboardingProps> = ({ overlay, onClose }) => {
   };
 
   const completeOnboarding = () => {
+    // Persist the completion flag under both keys so neither onboarding surface
+    // (this 5-step page and the feed overlay) re-triggers after completion.
     localStorage.setItem("zyeute_onboarded", "true");
+    localStorage.setItem("zyeute_onboarding_complete", "true");
+    // Always land on the feed. In overlay mode also close the sheet.
     if (overlay && onClose) {
       onClose();
-    } else {
-      navigate("/feed", { replace: true });
     }
+    navigate("/feed", { replace: true });
   };
 
   const handleSkip = () => {
@@ -261,8 +264,11 @@ export const Onboarding: React.FC<OnboardingProps> = ({ overlay, onClose }) => {
     }
   };
 
-  const handleFinish = async () => {
-    await savePreferences();
+  const handleFinish = () => {
+    // Persist preferences in the background — a slow/cold backend must never
+    // block (or fail) onboarding completion, otherwise the final CTA appears
+    // to do nothing and the user is stuck on the wizard.
+    void savePreferences();
     completeOnboarding();
   };
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -203,6 +203,7 @@ export const Profile: React.FC = () => {
   };
   const [isLoading, setIsLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
+  const [reloadKey, setReloadKey] = React.useState(0);
   const [gamification, setGamification] =
     React.useState<GamificationProfile | null>(null);
   const [activeTab, setActiveTab] = React.useState<"posts" | "fires" | "saved">(
@@ -361,16 +362,14 @@ export const Profile: React.FC = () => {
             setUser(profileUser);
             setError(null);
           } else {
-            // User not found, redirect home
-            navigate("/");
+            // User not found (404) or fetch failed — show an actionable error
+            // instead of a silent redirect that looks like an infinite skeleton.
+            setError("Profil introuvable. Réessaye!");
           }
         }
       } catch (error) {
         profileLogger.error("[Profile] Error fetching user:", error);
         setError("Impossible de charger le profil. Réessaye!");
-        if (username !== "me") {
-          navigate("/");
-        }
       } finally {
         setIsLoading(false);
       }
@@ -378,9 +377,23 @@ export const Profile: React.FC = () => {
 
     if (!username) return;
 
+    // Safety net: the skeleton must never be permanent. If the profile fetch
+    // somehow never settles (hung network, stalled session lookup), surface an
+    // error state with retry after a hard timeout.
+    const watchdog = setTimeout(() => {
+      setIsLoading((stillLoading) => {
+        if (stillLoading) {
+          setError("Le profil a mis trop de temps à charger. Réessaye!");
+        }
+        return false;
+      });
+    }, 12000);
+
     // Fetch immediately once auth is loaded
-    fetchUser();
-  }, [username, navigate, authUser, authLoading, isGuest]);
+    void fetchUser().finally(() => clearTimeout(watchdog));
+
+    return () => clearTimeout(watchdog);
+  }, [username, navigate, authUser, authLoading, isGuest, reloadKey]);
 
   // Fetch user posts + subscribe to Realtime for processing status updates
   React.useEffect(() => {
@@ -563,9 +576,24 @@ export const Profile: React.FC = () => {
           <p className="text-gray-400 mb-6">
             {error || "Impossible de charger le profil"}
           </p>
-          <GoldButton onClick={() => navigate("/")} size="md">
-            Retour à l'accueil
-          </GoldButton>
+          <div className="flex flex-col gap-3 items-center">
+            <GoldButton
+              onClick={() => {
+                setError(null);
+                setIsLoading(true);
+                setReloadKey((k) => k + 1);
+              }}
+              size="md"
+            >
+              Réessayer
+            </GoldButton>
+            <button
+              onClick={() => navigate("/")}
+              className="text-sm text-gold-500/70 hover:text-gold-400 transition"
+            >
+              Retour à l'accueil
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -631,7 +659,7 @@ export const Profile: React.FC = () => {
                     });
                   } else {
                     await navigator.clipboard.writeText(profileUrl);
-                    alert("Lien du profil copié! 📋");
+                    toast.success("Lien copié!");
                   }
                 } catch (error) {
                   profileLogger.error("Error sharing:", error);

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -7,7 +7,7 @@ import React from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@/components/Button";
 import { Logo } from "@/components/Logo";
-import { signUp } from "@/lib/supabase";
+import { signUp, signInWithGoogle } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import { toast } from "@/components/Toast";
 import {
@@ -117,6 +117,21 @@ export const Signup: React.FC = () => {
       // Only update state if component is still mounted
       if (isMountedRef.current) {
         setError(err.message || "Erreur lors de l'inscription");
+        setIsLoading(false);
+      }
+    }
+  };
+
+  const handleGoogleSignIn = async () => {
+    setError("");
+    setIsLoading(true);
+    try {
+      const { error } = await signInWithGoogle();
+      if (error) throw error;
+      // OAuth redirect happens via Supabase; nothing else to do here.
+    } catch (err: any) {
+      if (isMountedRef.current) {
+        setError(err?.message || "Erreur de connexion avec Google");
         setIsLoading(false);
       }
     }
@@ -277,6 +292,41 @@ export const Signup: React.FC = () => {
             <span className="mx-3 text-leather-400 text-xs">ou</span>
             <div className="flex-grow border-t border-leather-400" />
           </div>
+
+          {/* Google OAuth Button */}
+          <button
+            type="button"
+            onClick={handleGoogleSignIn}
+            disabled={isLoading}
+            className="w-full py-4 rounded-xl font-bold text-lg transition-all duration-300 flex items-center justify-center gap-3 mb-4"
+            style={{
+              background: "#ffffff",
+              border: "2px solid #dadce0",
+              color: "#3c4043",
+              boxShadow: "0 2px 4px rgba(0,0,0,0.2)",
+            }}
+            aria-label="Continuer avec Google"
+          >
+            <svg className="w-6 h-6" viewBox="0 0 24 24">
+              <path
+                fill="#4285F4"
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              />
+              <path
+                fill="#34A853"
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              />
+              <path
+                fill="#FBBC05"
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              />
+              <path
+                fill="#EA4335"
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              />
+            </svg>
+            Continuer avec Google
+          </button>
 
           {/* Continue as Guest Button */}
           <Button

--- a/frontend/src/pages/Upload.tsx
+++ b/frontend/src/pages/Upload.tsx
@@ -691,8 +691,8 @@ export const Upload: React.FC = () => {
             <span>Conseils Zyeuté</span>
           </h3>
           <ul className="space-y-2 text-leather-200 text-sm">
-            <li>⚜️ Use #Quebec #MTL for local reach</li>
-            <li>🔥 Vertical videos (9:16) perform best</li>
+            <li>⚜️ Utilise #Quebec #MTL pour rejoindre ta région</li>
+            <li>🔥 Les vidéos verticales (9:16) marchent le mieux</li>
           </ul>
         </div>
       </main>

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -22,6 +22,7 @@ function LoadingScreen({ message }: { message?: string }) {
 }
 
 const LoginPage = lazy(() => import("@/pages/Login"));
+const NotFoundPage = lazy(() => import("@/pages/NotFound"));
 const OnboardingPage = lazy(() => import("@/pages/Onboarding"));
 const AuthCallbackPage = lazy(() => import("@/pages/AuthCallback"));
 const Zyeute = lazy(() => import("@/pages/LaZyeute"));
@@ -140,10 +141,18 @@ function OnboardingGate({ children }: { children: ReactNode }) {
 
 /** Session or guest mode — required for account-style surfaces (not for public /feed). */
 function RequireAuth({ children }: { children: ReactNode }) {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, session, isLoading } = useAuth();
   const location = useLocation();
 
   if (isLoading) {
+    return <LoadingScreen message="Chargement..." />;
+  }
+
+  // A Supabase session exists but the profile is still hydrating (the emergency
+  // loading timeout can fire before enhanceUser resolves). Treat the session as
+  // authenticated so a hard navigation to a protected route does not bounce to
+  // /login before the profile arrives.
+  if (!isAuthenticated && session?.user) {
     return <LoadingScreen message="Chargement..." />;
   }
 
@@ -702,7 +711,7 @@ export function AppRoutes() {
           />
 
           <Route path="/" element={<Navigate to="/feed" replace />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
+          <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </Suspense>
     </RouteErrorBoundary>


### PR DESCRIPTION
## Summary

Fixes the broken core product loop identified in the June 11 2026 UX walkthrough (`audit/ux_bugs_brief.md`). All 5 P0 bugs plus the low-risk P1 quick wins. Diffs are surgical and build on PR #175's snake/camel mapping pattern. No arcade / live / economy / AI code touched.

## P0 — Core loop breakers

### 1. Comments fail to send ("Impossible d'envoyer le commentaire")
**Root cause:** In `POST /api/posts/:id/comments`, the push-notification and moderation-queue side-effects were `await`ed *before* sending the response. A slow or unreachable Redis/queue (cold-start on Render) blocked the handler past the frontend's 15s `apiCall` timeout → `AbortError` → `null` → error toast, even though the comment had already been persisted.
**Fix:** Respond `201` immediately after the insert + profile fetch, then run notification and moderation as non-blocking `void (async () => …)()` side-effects. Also emit dual snake/camel fields (`publication_id`/`postId`, `user_id`/`userId`, `created_at`/`createdAt`) on the comment payload so any client mapping works (#175 pattern). The insert already uses the correct FK columns (`publication_id`, `user_id`).
**Test:** Added `backend/routes/__tests__/comments.test.ts` — verifies persistence against the right columns, the dual-field response shape, and 400 on empty content. Both tests pass.

### 2. Onboarding completion loops back to step 2
**Root cause:** The step-5 CTA `handleFinish` awaited `savePreferences()` (which hits a possibly cold backend) before completing, and the completion path did not reliably navigate. The overlay variant never navigated at all.
**Fix:** `handleFinish` now fires `void savePreferences()` (non-blocking), then `completeOnboarding()` sets both `zyeute_onboarded` and `zyeute_onboarding_complete` flags and always `navigate("/feed", { replace: true })` (closing the sheet first in overlay mode).

### 3. Create page renders at URL `/login`
**Root cause:** The router already points "Créer" to `/upload` (guarded by `RequireAuth` → `RequireRealAccount`). The symptom came from the same hydration race as bug 5: on a hard navigation the guard saw `isAuthenticated === false` (profile not yet hydrated) and redirected to `/login` while the upload component was still mounted.
**Fix:** Covered by the bug 5 guard fix below.

### 4. Other users' profiles stuck on infinite skeleton
**Root cause:** On a failed/empty profile fetch the page silently `navigate("/")`'d (or, in edge cases, never left the `isLoading` skeleton), so the user saw a permanent skeleton with no feedback.
**Fix:** `frontend/src/pages/Profile.tsx` now sets an actionable error state ("Profil introuvable. Réessaye!") with a **Réessayer** retry button (via a `reloadKey`), and a 12s watchdog timer guarantees the skeleton can never be permanent — it flips to the error state if the fetch hangs.

### 5. Session drops on hard navigation to protected routes
**Root cause:** `AuthContext` resolves `isLoading=false` via a 3s emergency timeout, which can fire while `enhanceUser` (profile fetch, 4s timeout) is still pending. At that moment `isAuthenticated = !!user || isGuest` is `false` even though a valid Supabase session exists, so `RequireAuth` redirected to `/login`.
**Fix:** `RequireAuth` now shows the loading screen (instead of redirecting) when `!isAuthenticated && session?.user` — i.e. a session exists but the profile is still hydrating. `RequireRealAccount` already had the equivalent guard. This also fixes bug 3.

## P1 — Quick wins

6. **404 page** — new French `NotFound` page ("Page introuvable") with a link back to the feed; the catch-all route renders it instead of silently redirecting to `/`.
7. **French strings** — onboarding interest chip "Nightlife" → "Vie nocturne"; upload tips translated ("Utilise #Quebec #MTL pour rejoindre ta région", "Les vidéos verticales (9:16) marchent le mieux").
8. **Share** — feed share (`ShareSheet`) and `VideoCard` already implement `navigator.share()` + clipboard fallback + "Lien copié!" toast; replaced the profile page's `alert()` fallback with the same toast for consistency.
9. **Google OAuth on /signup** — added the same `signInWithGoogle()` button used on `/login`.

## Test plan

- [x] `backend/routes/__tests__/comments.test.ts` passes (2/2)
- [x] Typecheck introduces **zero** new errors (the 4 pre-existing errors in `backend/index.ts`, `AuthContext.tsx:21`, `ArcadePlayer.tsx` are present on `main` and unrelated; note `npm run check` is pre-broken by an invalid `ignoreDeprecations: "6.0"` in tsconfig for the pinned TS 5.9.3 — validated with `tsc --ignoreDeprecations 5.0`)
- [ ] Manual: submit a comment → appears without error toast
- [ ] Manual: complete onboarding step 5 → lands on /feed, does not loop
- [ ] Manual: hard-navigate to /upload while logged in → no bounce to /login
- [ ] Manual: open another user's profile → loads or shows retry, never infinite skeleton
- [ ] Manual: unknown URL → French 404; /signup shows Google button

🤖 Generated with [Claude Code](https://claude.com/claude-code)