### PR TITLE
fix(cors): 500 on any request with Origin header

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -16,6 +16,7 @@ if (
 }
 import express from "express";
 import cors from "cors";
+import { buildCorsOptions, resolveAllowedOrigins } from "./lib/cors.js";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import { registerRoutes } from "./routes.js";
@@ -51,41 +52,17 @@ const app = express();
 // Trust proxy (Railway, Vercel) - required for express-rate-limit to work behind reverse proxy
 app.set("trust proxy", 1);
 
-// CORS: allow frontend (Vercel / localhost) to call this backend
-const allowedOrigins = [
-  "https://www.zyeute.com",
-  "https://zyeute.com",
-  "https://zyeute.vercel.app",
-  "https://zyeutev5-production.up.railway.app",
-  "https://zyeutev5-1.onrender.com",
-  "http://localhost:12000",
-  "http://localhost:3000",
-  "http://localhost:5173",
-  "http://127.0.0.1:3000",
-  "http://127.0.0.1:5173",
-];
+// CORS: allow frontend (Vercel / localhost) to call this backend.
+// Origin allowlist + options live in ./lib/cors.ts. A disallowed Origin is
+// denied cleanly (no CORS headers) rather than throwing, so it can never bubble
+// into Express's default handler as a 500.
+const allowedOrigins = resolveAllowedOrigins();
+const corsOptions = buildCorsOptions(allowedOrigins);
 
-app.use(
-  cors({
-    origin: function (origin, callback) {
-      // Allow requests with no origin (mobile apps, curl, etc.)
-      if (!origin) return callback(null, true);
-      if (allowedOrigins.indexOf(origin) !== -1) {
-        callback(null, true);
-      } else {
-        console.log(`[CORS] Blocked origin: ${origin}`);
-        callback(new Error("Not allowed by CORS"));
-      }
-    },
-    credentials: true,
-    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
-    exposedHeaders: ["Content-Range", "X-Content-Range"],
-  }),
-);
+app.use(cors(corsOptions));
 
 // Handle OPTIONS preflight for all routes - use regex pattern to avoid path-to-regexp issues
-app.options(/.*/, cors());
+app.options(/.*/, cors(corsOptions));
 
 // helmet: baseline security headers (nosniff, HSTS, frameguard, etc.).
 // CSP is disabled because the API serves cross-origin JSON to the Vercel SPA and
@@ -226,7 +203,11 @@ io.use(async (socket, next) => {
     const headerAuth = socket.handshake.headers?.authorization;
     const queryToken = socket.handshake.query?.token;
     let token: string | undefined = auth.token;
-    if (!token && typeof headerAuth === "string" && headerAuth.startsWith("Bearer ")) {
+    if (
+      !token &&
+      typeof headerAuth === "string" &&
+      headerAuth.startsWith("Bearer ")
+    ) {
       token = headerAuth.slice("Bearer ".length).trim();
     }
     if (!token && typeof queryToken === "string") {
@@ -249,10 +230,7 @@ io.use(async (socket, next) => {
 // Strip HTML-significant characters so chat text can never be rendered as markup.
 function sanitizeChatText(input: unknown): string {
   if (typeof input !== "string") return "";
-  return input
-    .replace(/[<>]/g, "")
-    .slice(0, 200)
-    .trim();
+  return input.replace(/[<>]/g, "").slice(0, 200).trim();
 }
 
 io.on("connection", (socket) => {

--- a/backend/lib/__tests__/cors.test.ts
+++ b/backend/lib/__tests__/cors.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { Server } from "http";
+import {
+  buildCorsOptions,
+  resolveAllowedOrigins,
+  DEFAULT_ALLOWED_ORIGINS,
+} from "../cors.js";
+
+const PROD_ORIGIN = "https://zyeute-v5.vercel.app";
+
+// Build a minimal app that mirrors index.ts: cors middleware in front of a
+// /api/health route. This reproduces the production hotfix scenario where any
+// request carrying an Origin header returned 500.
+describe("CORS regression: 500 on any request with Origin header", () => {
+  let server: Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const express = (await import("express")).default;
+    const cors = (await import("cors")).default;
+    const app = express();
+    const opts = buildCorsOptions(resolveAllowedOrigins());
+    app.use(cors(opts));
+    app.options(/.*/, cors(opts));
+    app.get("/api/health", (_req, res) => {
+      res.status(200).json({ status: "ok" });
+    });
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("production Vercel origin is in the default allowlist", () => {
+    expect(DEFAULT_ALLOWED_ORIGINS).toContain(PROD_ORIGIN);
+  });
+
+  it("allowed Origin → 2xx with access-control-allow-origin", async () => {
+    const res = await fetch(`${baseUrl}/api/health`, {
+      headers: { Origin: PROD_ORIGIN },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBe(PROD_ORIGIN);
+  });
+
+  it("no Origin header → 2xx", async () => {
+    const res = await fetch(`${baseUrl}/api/health`);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe("ok");
+  });
+
+  it("unknown Origin → not 500 (denied cleanly, no CORS header)", async () => {
+    const res = await fetch(`${baseUrl}/api/health`, {
+      headers: { Origin: "https://evil.example.com" },
+    });
+    expect(res.status).not.toBe(500);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("preflight OPTIONS from allowed origin → no 500", async () => {
+    const res = await fetch(`${baseUrl}/api/health`, {
+      method: "OPTIONS",
+      headers: {
+        Origin: PROD_ORIGIN,
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+    expect(res.status).not.toBe(500);
+    expect(res.headers.get("access-control-allow-origin")).toBe(PROD_ORIGIN);
+  });
+
+  it("CORS_ALLOWED_ORIGINS env extends, never shrinks, the default baseline", () => {
+    const resolved = resolveAllowedOrigins({
+      CORS_ALLOWED_ORIGINS: "https://custom.example.com",
+    } as NodeJS.ProcessEnv);
+    expect(resolved).toContain("https://custom.example.com");
+    expect(resolved).toContain(PROD_ORIGIN);
+  });
+
+  it("missing CORS env still yields the safe default allowlist", () => {
+    const resolved = resolveAllowedOrigins({} as NodeJS.ProcessEnv);
+    expect(resolved).toEqual([...DEFAULT_ALLOWED_ORIGINS]);
+  });
+});

--- a/backend/lib/cors.ts
+++ b/backend/lib/cors.ts
@@ -1,0 +1,54 @@
+import type { CorsOptions } from "cors";
+
+// Sane default allowlist. Used when CORS_ALLOWED_ORIGINS is unset so that a
+// missing env var on a deploy target (e.g. Render) can never strip the
+// production frontend's access or crash request handling.
+export const DEFAULT_ALLOWED_ORIGINS: readonly string[] = [
+  "https://zyeute-v5.vercel.app",
+  "https://www.zyeute.com",
+  "https://zyeute.com",
+  "https://zyeute.vercel.app",
+  "https://zyeutev5-production.up.railway.app",
+  "https://zyeutev5-1.onrender.com",
+  "http://localhost:12000",
+  "http://localhost:3000",
+  "http://localhost:5173",
+  "http://127.0.0.1:3000",
+  "http://127.0.0.1:5173",
+];
+
+// Resolve the allowlist from CORS_ALLOWED_ORIGINS (comma-separated) and merge in
+// the defaults so config can extend — never silently shrink — the safe baseline.
+export function resolveAllowedOrigins(
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  const fromEnv = (env.CORS_ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+  return Array.from(new Set([...DEFAULT_ALLOWED_ORIGINS, ...fromEnv]));
+}
+
+// Build the cors() options. The origin callback NEVER passes an Error: a
+// disallowed origin resolves with `false`, so the cors middleware simply omits
+// the Access-Control-Allow-Origin header and the request continues to its route
+// (which returns its normal status). This prevents a disallowed Origin from
+// bubbling an Error into Express's default handler and producing a 500.
+export function buildCorsOptions(
+  allowedOrigins: string[] = resolveAllowedOrigins(),
+): CorsOptions {
+  return {
+    origin(origin, callback) {
+      // Requests with no Origin header (curl, server-to-server, same-origin
+      // navigations) are always allowed.
+      if (!origin) return callback(null, true);
+      if (allowedOrigins.includes(origin)) return callback(null, true);
+      console.log(`[CORS] Blocked origin: ${origin}`);
+      return callback(null, false);
+    },
+    credentials: true,
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
+    exposedHeaders: ["Content-Range", "X-Content-Range"],
+  };
+}


### PR DESCRIPTION
## Root cause

The Express backend returned **HTTP 500 for any request carrying an `Origin` header** — including `GET /api/health` — while the same requests without an `Origin` returned 200. This broke all browser writes (POSTs always send `Origin`), surfacing in the UI as *"Impossible d'envoyer le commentaire"*.

Two compounding bugs in `backend/index.ts`:

1. **Disallowed origins threw, producing a 500.** The CORS `origin` callback did `callback(new Error("Not allowed by CORS"))`. The `cors` package forwards that error to `next(err)` (`cors/lib/index.js:219-221`), and Express's **default error handler turns it into `500 Internal Server Error`**. So every request with an unlisted `Origin` 500'd instead of being denied cleanly.

2. **The production frontend origin was not in the allowlist.** The list contained `https://zyeute.vercel.app` but the live frontend is `https://zyeute-v5.vercel.app` (note `-v5`). So the real production origin hit bug #1 on every request — a guaranteed 500 for all browser traffic.

## Fix

Extracted CORS config into `backend/lib/cors.ts`:

- **Deny disallowed origins cleanly** with `callback(null, false)`. The `cors` package then omits `Access-Control-Allow-Origin` and lets the request continue to its route (normal status, never 500). The browser still blocks the cross-origin read — denial is enforced — but the server never errors.
- **Added `https://zyeute-v5.vercel.app`** to a sane default allowlist (`DEFAULT_ALLOWED_ORIGINS`).
- **Env-driven, crash-proof config:** `CORS_ALLOWED_ORIGINS` (comma-separated) is merged *with* the defaults via `resolveAllowedOrigins()`, so a missing/empty env var on Render can never strip the baseline allowlist or crash request handling. Config can extend, never silently shrink, the safe default.

`index.ts` now consumes `buildCorsOptions()` / `resolveAllowedOrigins()`; the Socket.IO server reuses the same resolved allowlist.

## Testing

`backend/lib/__tests__/cors.test.ts` (7 cases) covers the regression:

- allowed `Origin` → **2xx** with `access-control-allow-origin` echoed
- **no** `Origin` → **2xx**
- unknown `Origin` → **not 500** (200, no CORS header — denied cleanly)
- preflight `OPTIONS` from allowed origin → not 500, header present
- env extends (never shrinks) the default baseline; missing env → safe default

Results (run locally):
- `npm run check` (tsc `--noEmit`) → **pass**
- `npm test` (full vitest) → **71 passed** (64 prior + 7 new)
- new files `eslint` → clean (repo's pre-existing lint debt is unrelated and non-blocking in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed CORS handling to properly process cross-origin requests with Origin headers without returning errors.

* **Tests**
  * Added comprehensive test suite for CORS functionality, validating origin allowlisting, preflight requests, and environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->