### PR TITLE
feat(feed): seeded session shuffle so users don't see the same order

### DIFF
--- a/backend/routes/__tests__/feed-shuffle.test.ts
+++ b/backend/routes/__tests__/feed-shuffle.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { seededTierShuffle } from "../../../shared/utils/feedDedup.js";
+
+/** Ranked fixture pool (already sorted best-first, like the feed query). */
+function makePool(n: number): { id: string; viral_score: number }[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `post-${i}`,
+    viral_score: n - i,
+  }));
+}
+
+/**
+ * Mirrors the block-pagination slicing in getPostsViaSupabase: a single ranked
+ * block is tier-shuffled once with the (seed, blockIndex) pair, then pages are
+ * sliced out of that shuffled block.
+ */
+function pageFromBlock<T>(
+  block: T[],
+  seed: number,
+  blockIndex: number,
+  offsetInBlock: number,
+  limit: number,
+): T[] {
+  const shuffled = seededTierShuffle(
+    block,
+    (seed + blockIndex * 2654435761) >>> 0,
+  );
+  return shuffled.slice(offsetInBlock, offsetInBlock + limit);
+}
+
+describe("seededTierShuffle", () => {
+  it("returns the same order for the same seed", () => {
+    const pool = makePool(60);
+    const a = seededTierShuffle(pool, 12345);
+    const b = seededTierShuffle(pool, 12345);
+    expect(a.map((p) => p.id)).toEqual(b.map((p) => p.id));
+  });
+
+  it("returns a different order for different seeds", () => {
+    const pool = makePool(60);
+    const a = seededTierShuffle(pool, 12345);
+    const b = seededTierShuffle(pool, 67890);
+    expect(a.map((p) => p.id)).not.toEqual(b.map((p) => p.id));
+  });
+
+  it("is a permutation — no items added, dropped, or duplicated", () => {
+    const pool = makePool(60);
+    const shuffled = seededTierShuffle(pool, 42);
+    expect(shuffled).toHaveLength(pool.length);
+    expect(new Set(shuffled.map((p) => p.id)).size).toBe(pool.length);
+    expect([...shuffled.map((p) => p.id)].sort()).toEqual(
+      [...pool.map((p) => p.id)].sort(),
+    );
+  });
+
+  it("preserves quality bias: top-ranked items stay in the top region", () => {
+    const pool = makePool(100);
+    const shuffled = seededTierShuffle(pool, 999, 10);
+    // With tierSize 10, the highest-ranked 10 items only permute within slots
+    // 0–9, so every one of them stays in the first tier.
+    const topTenIds = new Set(pool.slice(0, 10).map((p) => p.id));
+    const firstTierIds = new Set(shuffled.slice(0, 10).map((p) => p.id));
+    expect(firstTierIds).toEqual(topTenIds);
+  });
+
+  it("handles empty and single-element pools", () => {
+    expect(seededTierShuffle([], 1)).toEqual([]);
+    expect(seededTierShuffle([{ id: "x" }], 1)).toEqual([{ id: "x" }]);
+  });
+});
+
+describe("seeded feed pagination", () => {
+  it("has no duplicates across pages within one block + seed", () => {
+    const seed = 555;
+    const limit = 20;
+    const block = makePool(120); // == FEED_BLOCK_SIZE
+    const seen = new Set<string>();
+    for (let page = 0; page < 6; page++) {
+      const offsetInBlock = (page * limit) % 120;
+      const pageItems = pageFromBlock(block, seed, 0, offsetInBlock, limit);
+      for (const item of pageItems) {
+        expect(seen.has(item.id)).toBe(false);
+        seen.add(item.id);
+      }
+    }
+    // All 120 block items surfaced exactly once across the 6 pages.
+    expect(seen.size).toBe(120);
+  });
+
+  it("returns identical pages when the same seed is replayed", () => {
+    const block = makePool(120);
+    const first = pageFromBlock(block, 777, 0, 0, 20);
+    const replay = pageFromBlock(block, 777, 0, 0, 20);
+    expect(first.map((p) => p.id)).toEqual(replay.map((p) => p.id));
+  });
+
+  it("yields a different first page for a different seed", () => {
+    const block = makePool(120);
+    const a = pageFromBlock(block, 111, 0, 0, 20);
+    const b = pageFromBlock(block, 222, 0, 0, 20);
+    expect(a.map((p) => p.id)).not.toEqual(b.map((p) => p.id));
+  });
+});

--- a/backend/routes/feed.ts
+++ b/backend/routes/feed.ts
@@ -14,8 +14,26 @@ import {
   interleaveQueues,
   mergeFeedWithDedup,
   prepareShuffledFeed,
+  seededTierShuffle,
   shuffleWithSeed,
 } from "../../shared/utils/feedDedup.js";
+
+/**
+ * Resolve a stable numeric shuffle seed for the feed. A client-supplied session
+ * token (persisted in sessionStorage) keeps order stable across paginated
+ * requests; absence of one yields a fresh random order per request.
+ */
+function resolveFeedSeed(sessionParam: unknown, viewerId?: string): number {
+  const session = typeof sessionParam === "string" ? sessionParam : "";
+  if (!session) return Math.floor(Math.random() * 1e9) >>> 0;
+  const base = `${session}:${viewerId ?? ""}`;
+  let h = 2166136261;
+  for (let i = 0; i < base.length; i++) {
+    h ^= base.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0 || 1;
+}
 
 const SUPABASE_URL =
   process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL || "";
@@ -242,14 +260,28 @@ async function fetchTikTokExploreSupabase(
     .slice(0, limit);
 }
 
+/**
+ * Block size for seeded-shuffle pagination. We fetch one ranked block, shuffle
+ * within quality tiers using the session seed, then slice the requested page out
+ * of it. Pages within the same block + seed are stable (no dupes / skips); the
+ * single block read keeps perf on par with the previous per-page query.
+ */
+const FEED_BLOCK_SIZE = 120;
+
 /** Fetch feed directly via Supabase HTTP — no DATABASE_URL needed */
 async function getPostsViaSupabase(
   limit: number,
   page: number,
   _hiveId = "quebec",
+  seed = 0,
 ) {
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
-  const offset = page * limit;
+
+  // Map the requested page onto a ranked block, then shuffle within that block.
+  const absoluteOffset = page * limit;
+  const blockIndex = Math.floor(absoluteOffset / FEED_BLOCK_SIZE);
+  const offsetInBlock = absoluteOffset % FEED_BLOCK_SIZE;
+  const blockStart = blockIndex * FEED_BLOCK_SIZE;
 
   const { data, error } = await supabase
     .from("publications")
@@ -265,10 +297,20 @@ async function getPostsViaSupabase(
     )
     .order("viral_score", { ascending: false })
     .order("reactions_count", { ascending: false })
-    .range(offset, offset + limit - 1);
+    .range(blockStart, blockStart + FEED_BLOCK_SIZE - 1);
 
   if (error) throw new Error(error.message);
-  return data || [];
+
+  const block = data || [];
+  if (seed === 0) return block.slice(offsetInBlock, offsetInBlock + limit);
+
+  // Quality-preserving seeded shuffle: viral content stays near top, order
+  // varies per session. Tier offset by block keeps blocks from aligning.
+  const shuffled = seededTierShuffle(
+    block as Record<string, unknown>[],
+    (seed + blockIndex * 2654435761) >>> 0,
+  );
+  return shuffled.slice(offsetInBlock, offsetInBlock + limit);
 }
 
 const router = Router();
@@ -304,13 +346,15 @@ router.get("/", optionalAuth, async (req: Request, res: Response) => {
     const page = parseInt(req.query.page as string) || 0;
     const limit = parseInt(req.query.limit as string) || 20;
     const hive = (req.query.hive as string) || "quebec";
+    const seed = resolveFeedSeed(req.query.session, (req as any).userId);
 
     // Try Supabase HTTP first (always works)
     if (SUPABASE_URL && SUPABASE_KEY) {
-      const posts = await getPostsViaSupabase(limit, page, hive);
+      const posts = await getPostsViaSupabase(limit, page, hive, seed);
       return res.json({
         posts,
         nextCursor: posts.length === limit ? String(page + 1) : null,
+        seed,
         isGuestMode: !(req as any).userId,
         source: "supabase",
       });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -9,6 +9,7 @@ import type { Post, User, Story, Comment, Notification } from "@/types";
 const apiLogger = logger.withContext("API");
 
 import { getSessionWithTimeout } from "@/lib/supabase";
+import { getOrCreateFeedSessionId } from "@/lib/feedSession";
 import {
   AIImageResponseSchema,
   AIVideoResponseSchema,
@@ -255,8 +256,12 @@ export async function getFeedPosts(
   limit: number = 20,
 ): Promise<Post[]> {
   try {
+    // Stable per-session seed → feed order varies between sessions but stays
+    // consistent across paginated requests (no dupes/skips). Rotated on reload
+    // / pull-to-refresh via feedSession helpers.
+    const session = encodeURIComponent(getOrCreateFeedSessionId());
     const { data, error } = await apiCall<{ posts: Post[] }>(
-      `/feed?page=${page}&limit=${limit}`,
+      `/feed?page=${page}&limit=${limit}&session=${session}`,
     );
 
     if (error || !data) {

--- a/shared/utils/feedDedup.ts
+++ b/shared/utils/feedDedup.ts
@@ -71,6 +71,31 @@ export function shuffleWithSeed<T>(arr: T[], seed: number): T[] {
   return a;
 }
 
+/**
+ * Quality-preserving seeded shuffle: keep the ranked pool's bias toward viral/
+ * fresh content by splitting it into fixed-size tiers (top-ranked items first)
+ * and shuffling only *within* each tier with the seed. Same seed → same order
+ * (pagination-safe); different seed → different order. Viral content stays near
+ * the top across sessions; only the intra-tier ordering varies.
+ *
+ * The input is expected to be pre-sorted best-first (e.g. by viral_score).
+ */
+export function seededTierShuffle<T>(
+  ranked: T[],
+  seed: number,
+  tierSize = 10,
+): T[] {
+  if (ranked.length <= 1) return [...ranked];
+  const size = Math.max(1, Math.floor(tierSize));
+  const out: T[] = [];
+  for (let start = 0; start < ranked.length; start += size) {
+    const tier = ranked.slice(start, start + size);
+    // Offset the seed per tier so tiers don't all permute identically.
+    out.push(...shuffleWithSeed(tier, (seed + start * 2654435761) >>> 0));
+  }
+  return out;
+}
+
 /** Round-robin across creators so one account cannot dominate consecutive slots. */
 export function interleaveByAuthor<T extends Record<string, unknown>>(
   posts: T[],


### PR DESCRIPTION
## Summary

The basic `GET /api/feed` route (used by `getFeedPosts` in the frontend) returned posts in the **same `viral_score` order for every user and every session**, so users kept seeing the same videos at the top. This adds a seeded, pagination-safe shuffle that varies feed order between sessions while preserving the existing bias toward viral/fresh content.

### Design

- **Seeded, pagination-safe shuffle.** A new pure helper `seededTierShuffle` (in `shared/utils/feedDedup.ts`) takes the already-ranked pool, splits it into fixed-size tiers (top-ranked first), and shuffles only *within* each tier using a session seed (reusing the existing deterministic `shuffleWithSeed`). Same seed → same order; different seed → different order.
- **Quality weighting preserved.** Because the pool is still fetched ranked by `viral_score` / `reactions_count` and only permuted within tiers, viral/fresh content stays near the top — order varies but quality bias is intact.
- **Pagination stability + perf.** `getPostsViaSupabase` now maps the requested page onto a single ranked **block** (`FEED_BLOCK_SIZE = 120`), shuffles that block once with `(seed, blockIndex)`, then slices the page out. Pages within a block + seed never duplicate or skip items. No extra queries vs. the previous per-page query, and the `SELECT`/`ORDER` shape is unchanged (does not worsen the known `SELECT *` / offset perf debt).
- **Seed source.** The route reads a `session` query param and hashes it (FNV-1a, mixed with the viewer id) into a stable numeric seed; the resolved seed is returned in the response. **No session → fresh random order** per request.
- **Frontend.** `getFeedPosts` now passes a `session` seed sourced from the existing `getOrCreateFeedSessionId()` (persisted in `sessionStorage`, regenerated on reload / pull-to-refresh via the existing `feedSession` helpers).

`backend/index.ts` was intentionally **not touched** to avoid conflicts with the concurrent CORS fix.

### Files changed
- `shared/utils/feedDedup.ts` — add `seededTierShuffle`
- `backend/routes/feed.ts` — seed resolution + block-based seeded shuffle in `GET /` (no `index.ts` changes)
- `frontend/src/services/api.ts` — pass `session` seed from `feedSession`
- `backend/routes/__tests__/feed-shuffle.test.ts` — new tests

## Testing
- [x] `npm test` — 79/79 pass (11 files), including 8 new shuffle tests
- [x] New tests cover: same seed → same order; different seeds → different order; permutation (no add/drop/dup); quality bias (top tier stays on top); pagination across pages has **no duplicates**; replayed seed → identical page
- [x] `eslint` clean on all changed files (no new warnings/errors)
- [ ] `tsc --noEmit` — a pre-existing `node_modules` `.d.ts` syntax error (`@google-cloud/aiplatform`, TS1005) is present on `main` independent of this change; all first-party source type-checks cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)