### PR TITLE
fix(feed): serve playable posts stuck in processing + drop dead proxy URLs

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -621,6 +621,17 @@ app.use((req, res, next) => {
       console.error("🚨 [Scoring] Engine setup failed:", err);
     }
 
+    // [FEED RECONCILER] Flip stuck 'processing'/'pending' publications with an
+    // hls_url to 'completed' via the Supabase HTTP client (the Mux webhook's
+    // direct-DB pool times out in prod). Fail-safe — never crashes boot.
+    try {
+      const { startFeedStatusReconciler } =
+        await import("./services/feed-status-reconciler.js");
+      startFeedStatusReconciler();
+    } catch (err) {
+      console.warn("⚠️ [Startup] Feed reconciler setup skipped:", err);
+    }
+
     app.use("/api/tiguy", tiGuyRouter);
     app.use("/api/hive", hiveRouter);
     app.use("/api/messaging", messagingRouter);

--- a/backend/routes/feed.ts
+++ b/backend/routes/feed.ts
@@ -289,11 +289,15 @@ async function getPostsViaSupabase(
     .eq("visibility", "public")
     .eq("est_masque", false)
     .is("deleted_at", null)
-    .eq("processing_status", "completed")
-    .not("media_url", "is", null)
-    // Only serve permanent video sources (Mux HLS, Supabase storage, reliable CDNs) and TikTok
     .or(
-      "media_url.ilike.%mux.com%,media_url.ilike.%supabase.co%,media_url.ilike.%.m3u8,media_url.ilike.%image.mux.com%,media_url.ilike.%pexels.com%,media_url.ilike.%videos.pexels.com%,media_url.ilike.%pixabay.com%,media_url.ilike.%cdn.pixabay.com%,media_url.ilike.%commondatastorage.googleapis.com%,media_url.ilike.%tiktok%,media_url.ilike.%tiktokv.com%,media_url.ilike.%tiktokcdn%,media_url.ilike.%tikcdn%,media_url.ilike.%byteoversea%,media_url.ilike.%muscdn%,media_url.ilike.%v16-webapp%,media_url.ilike.%v19-webapp%,media_url.ilike.%googleapis.com%",
+      "processing_status.eq.completed,processing_status.is.null,mux_playback_id.not.is.null",
+    )
+    .not("media_url", "is", null)
+    // Exclude expired media-proxy URLs (signed TikTok CDN links that 403)
+    .not("media_url", "ilike", "/api/media-proxy%")
+    // Only serve permanent video sources (Mux HLS, Supabase storage, stock CDNs)
+    .or(
+      "media_url.ilike.%mux.com%,media_url.ilike.%supabase.co%,media_url.ilike.%.m3u8,media_url.ilike.%image.mux.com%,media_url.ilike.%pexels.com%,media_url.ilike.%videos.pexels.com%,media_url.ilike.%pixabay.com%,media_url.ilike.%cdn.pixabay.com%,media_url.ilike.%commondatastorage.googleapis.com%,media_url.ilike.%googleapis.com%",
     )
     .order("viral_score", { ascending: false })
     .order("reactions_count", { ascending: false })

--- a/backend/services/feed-status-reconciler.ts
+++ b/backend/services/feed-status-reconciler.ts
@@ -1,0 +1,74 @@
+/**
+ * Feed status reconciler.
+ *
+ * The Mux webhook flips `processing_status` to 'completed' via the Drizzle
+ * direct-DB pool, but those connections time out in production, leaving
+ * playable assets (Mux playback id + hls_url present) stuck as 'processing'
+ * or 'pending' and excluded from the feed. This reconciler patches that state
+ * over the Supabase HTTP client, which is reliable in prod.
+ *
+ * It is fail-safe by design: any error is logged and swallowed so it can never
+ * crash boot or the interval tick.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+
+const RECONCILE_INTERVAL_MS = 10 * 60 * 1000;
+
+async function reconcileFeedStatuses(): Promise<void> {
+  try {
+    const supabaseUrl =
+      process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || "";
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+    if (!supabaseUrl || !serviceKey) {
+      console.warn(
+        "[FeedReconciler] Skipped — SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set",
+      );
+      return;
+    }
+
+    const supabase = createClient(supabaseUrl, serviceKey);
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+
+    const { data, error } = await supabase
+      .from("publications")
+      .update({ processing_status: "completed" })
+      .in("processing_status", ["processing", "pending"])
+      .not("hls_url", "is", null)
+      .lt("created_at", fiveMinutesAgo)
+      .select("id");
+
+    if (error) {
+      console.warn("[FeedReconciler] Update failed:", error.message);
+      return;
+    }
+
+    const count = data?.length ?? 0;
+    if (count > 0) {
+      console.log(
+        `[FeedReconciler] Marked ${count} stuck publication(s) as completed`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      "[FeedReconciler] Reconcile tick failed:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+/** Runs the reconciler once on boot, then every 10 minutes. Never throws. */
+export function startFeedStatusReconciler(): void {
+  try {
+    void reconcileFeedStatuses();
+    setInterval(() => {
+      void reconcileFeedStatuses();
+    }, RECONCILE_INTERVAL_MS);
+    console.log("✅ [Startup] Feed status reconciler scheduled (every 10 min)");
+  } catch (err) {
+    console.warn(
+      "[FeedReconciler] Failed to schedule:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Production incident: the feed showed only unplayable videos. Two root causes in `getPostsViaSupabase` (backend/routes/feed.ts):

1. **Strict `processing_status = 'completed'` filter** excluded 92 posts created today that are fully playable (Mux `mux_playback_id` + `hls_url` set, m3u8 returns 200) but stuck at `processing_status='processing'`. The Mux webhook can't flip them because it writes through the Drizzle direct-DB pool, whose `DATABASE_URL` connections time out in prod ("timeout exceeded when trying to connect").
2. **Signed/expiring TikTok CDN domains in the media_url allowlist** surfaced 268 posts (75 in the top block) whose `media_url` is `/api/media-proxy?url=<signed v16-webapp URL>`. Those signed URLs have expired — the proxy 403s — yet they rank top via `viral_score`.

### Changes

- **A.** Replace `.eq("processing_status","completed")` with the OR form already used elsewhere in the file: `processing_status.eq.completed,processing_status.is.null,mux_playback_id.not.is.null`. (`feed-supabase.ts` already used this form and had no media_url allowlist, so no change there.)
- **B.** Remove all signed/expiring TikTok CDN domains (`tiktok`, `tiktokv`, `tiktokcdn`, `tikcdn`, `byteoversea`, `muscdn`, `v16-webapp`, `v19-webapp`) from the media_url allowlist, keeping only permanent sources (mux.com, image.mux.com, supabase.co, .m3u8, pexels, pixabay, googleapis). Also exclude posts whose `media_url` starts with `/api/media-proxy`.
- **C.** Add `backend/services/feed-status-reconciler.ts`: a fail-safe reconciler that, using the **Supabase HTTP client with `SUPABASE_SERVICE_ROLE_KEY`** (not the Drizzle pool), marks `publications` with `processing_status in ('processing','pending')`, a non-null `hls_url`, and `created_at < now() - 5 min` as `completed`. Runs on boot and every 10 minutes; wrapped in try/catch so it can never crash boot. Wired into `backend/index.ts`.

No DB changes. The Mux webhook signature verification is untouched.

## Testing

- `npm test` (vitest) — **79 passed**, including `backend/routes/__tests__/feed-shuffle.test.ts`. The shuffle test asserts the pure `seededTierShuffle` slicing logic, which is unchanged, so no test adjustment was needed.
- `npm run check` (`tsc --noEmit`) — **passes clean** (0 errors).
- `npx eslint` on changed files — **0 errors** (new reconciler adds no warnings; remaining warnings are pre-existing repo debt).

---
🤖 *Generated by Computer*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved feed stability by filtering out expired media links that were causing display errors.

* **New Features**
  * Added automatic feed reconciliation that periodically recovers publications stuck in processing or pending states, enhancing feed reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->