### PR TITLE
feat(feed): surface unseen videos before watched ones

### DIFF
--- a/backend/routes/__tests__/feed-shuffle.test.ts
+++ b/backend/routes/__tests__/feed-shuffle.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { seededTierShuffle } from "../../../shared/utils/feedDedup.js";
+import {
+  seededTierShuffle,
+  unseenFirst,
+} from "../../../shared/utils/feedDedup.js";
 
 /** Ranked fixture pool (already sorted best-first, like the feed query). */
 function makePool(n: number): { id: string; viral_score: number }[] {
@@ -99,5 +102,59 @@ describe("seeded feed pagination", () => {
     const a = pageFromBlock(block, 111, 0, 0, 20);
     const b = pageFromBlock(block, 222, 0, 0, 20);
     expect(a.map((p) => p.id)).not.toEqual(b.map((p) => p.id));
+  });
+});
+
+describe("unseenFirst", () => {
+  const pool = makePool(10);
+
+  it("returns the original order when nothing is watched", () => {
+    const out = unseenFirst(pool, new Set());
+    expect(out.map((p) => p.id)).toEqual(pool.map((p) => p.id));
+  });
+
+  it("moves watched posts after unseen ones, stable within each group", () => {
+    // Mark a few mid-list posts as watched.
+    const seen = new Set(["post-1", "post-4", "post-7"]);
+    const out = unseenFirst(pool, seen).map((p) => p.id);
+
+    const unseen = pool.map((p) => p.id).filter((id) => !seen.has(id));
+    const watched = pool.map((p) => p.id).filter((id) => seen.has(id));
+
+    // Unseen come first in their original relative order…
+    expect(out.slice(0, unseen.length)).toEqual(unseen);
+    // …then the watched ones, also in original relative order.
+    expect(out.slice(unseen.length)).toEqual(watched);
+  });
+
+  it("never drops, adds, or duplicates posts", () => {
+    const seen = new Set(["post-2", "post-3", "post-9"]);
+    const out = unseenFirst(pool, seen);
+    expect(out).toHaveLength(pool.length);
+    expect([...out.map((p) => p.id)].sort()).toEqual(
+      [...pool.map((p) => p.id)].sort(),
+    );
+  });
+
+  it("falls back to the full ranked list when every post is watched", () => {
+    const seen = new Set(pool.map((p) => p.id));
+    const out = unseenFirst(pool, seen);
+    // No empty feed — original order is preserved untouched.
+    expect(out.map((p) => p.id)).toEqual(pool.map((p) => p.id));
+  });
+
+  it("composes with the tier shuffle: unseen-first over a shuffled block", () => {
+    const block = makePool(120);
+    const shuffled = seededTierShuffle(block, 4242);
+    const seen = new Set(
+      shuffled.slice(0, 30).map((p) => p.id), // pretend the first 30 were watched
+    );
+    const out = unseenFirst(shuffled, seen);
+    const splitAt = shuffled.length - seen.size;
+    // Everything before the split is unseen, everything after is watched.
+    expect(out.slice(0, splitAt).every((p) => !seen.has(p.id))).toBe(true);
+    expect(out.slice(splitAt).every((p) => seen.has(p.id))).toBe(true);
+    // Still a permutation of the block.
+    expect(new Set(out.map((p) => p.id)).size).toBe(block.length);
   });
 });

--- a/backend/routes/feed.ts
+++ b/backend/routes/feed.ts
@@ -16,6 +16,7 @@ import {
   prepareShuffledFeed,
   seededTierShuffle,
   shuffleWithSeed,
+  unseenFirst,
 } from "../../shared/utils/feedDedup.js";
 
 /**
@@ -56,6 +57,26 @@ async function attachOptionalUser(
     if (userId) (req as any).userId = userId;
   }
   next();
+}
+
+/** Max guest seen ids honored per request (mirrors the client cap). */
+const GUEST_SEEN_LIMIT = 50;
+
+/**
+ * Recently-watched post ids supplied by a guest client. Read from the
+ * `x-seen-ids` header (preferred — keeps the URL short) or the `seen` query
+ * param as a fallback. Comma-separated, capped to the most recent ids.
+ */
+function parseSeenIds(req: Request): string[] {
+  const raw =
+    (req.headers["x-seen-ids"] as string | undefined) ||
+    (typeof req.query.seen === "string" ? (req.query.seen as string) : "");
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .slice(0, GUEST_SEEN_LIMIT);
 }
 
 function isTikTokStylePost(p: Record<string, unknown>): boolean {
@@ -268,12 +289,42 @@ async function fetchTikTokExploreSupabase(
  */
 const FEED_BLOCK_SIZE = 120;
 
+/** Cap on how many recently-watched ids we pull from video_views per request. */
+const WATCHED_LOOKBACK = 500;
+
+/**
+ * Recently-watched publication ids for an authenticated viewer, newest first.
+ * Uses the Supabase JS client (service role) — the drizzle/pg pool times out
+ * in production, so all reads here go through Supabase HTTP.
+ */
+async function fetchWatchedPostIds(
+  supabase: SupabaseClient,
+  viewerId: string,
+): Promise<string[]> {
+  try {
+    const { data, error } = await supabase
+      .from("video_views")
+      .select("publication_id")
+      .eq("user_id", viewerId)
+      .order("watched_at", { ascending: false })
+      .limit(WATCHED_LOOKBACK);
+    if (error || !data) return [];
+    return data
+      .map((r: { publication_id: string | null }) => r.publication_id)
+      .filter((id): id is string => !!id);
+  } catch {
+    return [];
+  }
+}
+
 /** Fetch feed directly via Supabase HTTP — no DATABASE_URL needed */
 async function getPostsViaSupabase(
   limit: number,
   page: number,
   _hiveId = "quebec",
   seed = 0,
+  viewerId?: string,
+  guestSeenIds: string[] = [],
 ) {
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
@@ -282,6 +333,14 @@ async function getPostsViaSupabase(
   const blockIndex = Math.floor(absoluteOffset / FEED_BLOCK_SIZE);
   const offsetInBlock = absoluteOffset % FEED_BLOCK_SIZE;
   const blockStart = blockIndex * FEED_BLOCK_SIZE;
+
+  // Watched-video knowledge: authed users from video_views, guests from the
+  // client-supplied list. Unseen posts are surfaced before watched ones.
+  const seen = new Set<string>(guestSeenIds.map(String));
+  if (viewerId) {
+    const watchedIds = await fetchWatchedPostIds(supabase, viewerId);
+    for (const id of watchedIds) seen.add(id);
+  }
 
   const { data, error } = await supabase
     .from("publications")
@@ -305,16 +364,22 @@ async function getPostsViaSupabase(
 
   if (error) throw new Error(error.message);
 
-  const block = data || [];
-  if (seed === 0) return block.slice(offsetInBlock, offsetInBlock + limit);
+  const block = (data || []) as Record<string, unknown>[];
+  if (seed === 0) {
+    const ordered = unseenFirst(block, seen);
+    return ordered.slice(offsetInBlock, offsetInBlock + limit);
+  }
 
   // Quality-preserving seeded shuffle: viral content stays near top, order
   // varies per session. Tier offset by block keeps blocks from aligning.
   const shuffled = seededTierShuffle(
-    block as Record<string, unknown>[],
+    block,
     (seed + blockIndex * 2654435761) >>> 0,
   );
-  return shuffled.slice(offsetInBlock, offsetInBlock + limit);
+  // Promote unseen posts ahead of watched ones while keeping the tier-shuffled
+  // order within each group. Falls back to the full list when all are watched.
+  const ordered = unseenFirst(shuffled, seen);
+  return ordered.slice(offsetInBlock, offsetInBlock + limit);
 }
 
 const router = Router();
@@ -350,11 +415,23 @@ router.get("/", optionalAuth, async (req: Request, res: Response) => {
     const page = parseInt(req.query.page as string) || 0;
     const limit = parseInt(req.query.limit as string) || 20;
     const hive = (req.query.hive as string) || "quebec";
-    const seed = resolveFeedSeed(req.query.session, (req as any).userId);
+    const viewerId = (req as any).userId as string | undefined;
+    const seed = resolveFeedSeed(req.query.session, viewerId);
+
+    // Guests have no video_views rows; the client sends its recently-watched ids
+    // (capped, last ~50) so we can deprioritize them. Header keeps the URL short.
+    const guestSeenIds = viewerId ? [] : parseSeenIds(req);
 
     // Try Supabase HTTP first (always works)
     if (SUPABASE_URL && SUPABASE_KEY) {
-      const posts = await getPostsViaSupabase(limit, page, hive, seed);
+      const posts = await getPostsViaSupabase(
+        limit,
+        page,
+        hive,
+        seed,
+        viewerId,
+        guestSeenIds,
+      );
       return res.json({
         posts,
         nextCursor: posts.length === limit ? String(page + 1) : null,

--- a/frontend/src/components/features/ContinuousFeed.tsx
+++ b/frontend/src/components/features/ContinuousFeed.tsx
@@ -55,6 +55,8 @@ import {
 } from "@/services/api";
 import { triggerBadgeCheck } from "@/services/gamificationService";
 import { pourToiRank, fetchWatchHistory } from "@/lib/pourToiRanker";
+import { recordWatch } from "@/lib/watchTracking";
+import { useAuth } from "@/hooks/useAuth";
 
 function allowDemoVideos(): boolean {
   return (
@@ -308,6 +310,7 @@ export const ContinuousFeed: React.FC<ContinuousFeedProps> = ({
   const { tap } = useHaptics();
   const { getFeedState, saveFeedState } = useNavigationState();
   const { isOnline, addToQueue } = useNetworkQueue();
+  const { user } = useAuth();
 
   const hasInitializedRef = useRef(false); // Prevent double-fetch in StrictMode
   const isFetchingRef = useRef(false); // Prevent concurrent fetches
@@ -395,6 +398,21 @@ export const ContinuousFeed: React.FC<ContinuousFeedProps> = ({
   useEffect(() => {
     postsRef.current = posts;
   }, [posts]);
+
+  // Record the active video as watched after a 2s dwell so the feed can surface
+  // unseen videos first on the next visit. Fire-and-forget; fast scroll-through
+  // (< 2s) is not counted as a watch. Guests are tracked in localStorage,
+  // authenticated users additionally persist to video_views.
+  useEffect(() => {
+    const active = posts[currentIndex];
+    if (!active?.id || String(active.id).startsWith("demo-")) return;
+    const postId = String(active.id);
+    const isAuthed = !!user;
+    const timer = setTimeout(() => {
+      recordWatch(postId, { isAuthenticated: isAuthed });
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, [currentIndex, posts, user]);
 
   // Save state on unmount
   useEffect(() => {

--- a/frontend/src/lib/watchTracking.ts
+++ b/frontend/src/lib/watchTracking.ts
@@ -1,0 +1,71 @@
+/**
+ * Watched-video tracking. Authenticated users are recorded server-side in
+ * video_views via POST /api/feed/watched; the feed reads that to surface unseen
+ * videos first. Guests have no server rows, so we keep a capped list of watched
+ * post ids in localStorage and send the most recent ones with each feed request.
+ */
+import { apiCall } from "@/services/api";
+
+const GUEST_SEEN_KEY = "zyeute_seen_posts";
+/** Total ids retained locally for guests. */
+const GUEST_SEEN_CAP = 200;
+/** Ids sent per feed request — keep small so the header/URL stays short. */
+const GUEST_SEEN_SEND = 50;
+
+function readGuestSeen(): string[] {
+  try {
+    const raw = localStorage.getItem(GUEST_SEEN_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x) => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeGuestSeen(ids: string[]): void {
+  try {
+    localStorage.setItem(GUEST_SEEN_KEY, JSON.stringify(ids));
+  } catch {
+    /* storage full / unavailable — non-critical */
+  }
+}
+
+/** Record a watched post id locally (most-recent-first, deduped, capped). */
+export function addGuestSeen(postId: string): void {
+  if (!postId) return;
+  const current = readGuestSeen().filter((id) => id !== postId);
+  current.unshift(postId);
+  writeGuestSeen(current.slice(0, GUEST_SEEN_CAP));
+}
+
+/** Most recently watched guest ids to send with a feed request. */
+export function getGuestSeenForRequest(): string[] {
+  return readGuestSeen().slice(0, GUEST_SEEN_SEND);
+}
+
+/**
+ * Record that a video was watched. Fire-and-forget: always update the local
+ * guest list, and additionally persist to video_views when authenticated.
+ * `isAuthenticated` lets callers skip the network round-trip for guests.
+ */
+export function recordWatch(
+  postId: string,
+  opts: { isAuthenticated: boolean; watchDurationMs?: number; completionRate?: number } = {
+    isAuthenticated: false,
+  },
+): void {
+  if (!postId) return;
+  addGuestSeen(postId);
+  if (!opts.isAuthenticated) return;
+  void apiCall("/feed/watched", {
+    method: "POST",
+    body: JSON.stringify({
+      publicationId: postId,
+      watchDurationMs: opts.watchDurationMs,
+      completionRate: opts.completionRate,
+    }),
+  }).catch(() => {
+    /* watch tracking is non-critical */
+  });
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -10,6 +10,7 @@ const apiLogger = logger.withContext("API");
 
 import { getSessionWithTimeout } from "@/lib/supabase";
 import { getOrCreateFeedSessionId } from "@/lib/feedSession";
+import { getGuestSeenForRequest } from "@/lib/watchTracking";
 import {
   AIImageResponseSchema,
   AIVideoResponseSchema,
@@ -260,8 +261,15 @@ export async function getFeedPosts(
     // consistent across paginated requests (no dupes/skips). Rotated on reload
     // / pull-to-refresh via feedSession helpers.
     const session = encodeURIComponent(getOrCreateFeedSessionId());
+    // Guests have no server-side video_views; send their recently-watched ids so
+    // the backend can surface unseen videos first. Authed users are read from
+    // video_views server-side and don't need this. Sent via header to keep the
+    // URL short. (apiCall attaches a Bearer token only when signed in.)
+    const seenIds = getGuestSeenForRequest();
+    const headers = seenIds.length ? { "x-seen-ids": seenIds.join(",") } : undefined;
     const { data, error } = await apiCall<{ posts: Post[] }>(
       `/feed?page=${page}&limit=${limit}&session=${session}`,
+      headers ? { headers } : {},
     );
 
     if (error || !data) {

--- a/shared/utils/feedDedup.ts
+++ b/shared/utils/feedDedup.ts
@@ -96,6 +96,28 @@ export function seededTierShuffle<T>(
   return out;
 }
 
+/**
+ * Stable partition that surfaces unwatched posts before watched ones. Posts
+ * whose id is NOT in `seen` keep their relative order and come first; watched
+ * posts keep their relative order and follow. When every post is watched (or
+ * `seen` is empty) the input order is returned unchanged, so the feed is never
+ * emptied or reordered without reason.
+ */
+export function unseenFirst<T extends { id?: unknown }>(
+  posts: T[],
+  seen: Set<string>,
+): T[] {
+  if (seen.size === 0) return posts;
+  const unseen: T[] = [];
+  const watched: T[] = [];
+  for (const p of posts) {
+    if (seen.has(String(p.id))) watched.push(p);
+    else unseen.push(p);
+  }
+  if (unseen.length === 0) return posts;
+  return [...unseen, ...watched];
+}
+
 /** Round-robin across creators so one account cannot dominate consecutive slots. */
 export function interleaveByAuthor<T extends Record<string, unknown>>(
   posts: T[],


### PR DESCRIPTION
## Summary

The feed always showed the same videos at the top every visit: ranking in `getPostsViaSupabase` is `viral_score desc + reactions_count desc` over a 120-item block with a per-session tier shuffle, so the same top block surfaced every session. This adds watched-video knowledge — users now see videos they haven't watched yet, with watched ones deprioritized.

### What changed

- **Backend (`backend/routes/feed.ts`)** — `getPostsViaSupabase` (the path serving `/api/feed`, `source:"supabase"`) now accepts the authenticated `viewerId` (from the existing `optionalAuth` middleware) and a guest seen-id list. It fetches the viewer's recently-watched publication ids from `video_views` (cap 500, newest first) via the **Supabase JS client (service role)** — not the drizzle/pg pool, which times out in production. Unseen posts are ranked **before** watched ones, stable within each group, preserving the existing tier shuffle.
- **`shared/utils/feedDedup.ts`** — new `unseenFirst(posts, seen)` helper: stable partition, unseen first. When every post is watched (or `seen` is empty) it returns the input unchanged, so **the feed is never empty** (all-watched fallback).
- **Guests (`frontend/src/lib/watchTracking.ts`, `api.ts`)** — guests have no `video_views` rows, so the client keeps a capped (200) localStorage list of watched ids and sends the most recent 50 via the `x-seen-ids` header (keeps the URL short). The backend treats them like watched ids.
- **View tracking (`ContinuousFeed.tsx`)** — confirmed no watch recording existed. Now wired: after a 2s dwell on the active video, `recordWatch` fires (fire-and-forget). Authenticated users persist to `video_views` via the existing `POST /api/feed/watched` endpoint (already Supabase-client based); guests update localStorage. Demo videos are skipped.

### View tracking flow end-to-end

1. User dwells ≥2s on the active video in `ContinuousFeed`.
2. `recordWatch(postId, { isAuthenticated })` fires: always updates the guest localStorage list; if authed, also `POST /api/feed/watched` → upserts `video_views` (Supabase client, service role).
3. Next feed request: authed users' watched ids are read server-side from `video_views`; guests send recent ids via `x-seen-ids`.
4. `getPostsViaSupabase` partitions the ranked/shuffled block with `unseenFirst` → unwatched videos first.

## Testing

- [x] `npx vitest run backend/ shared/` — 44 passed, including 5 new `unseenFirst` cases (unseen-first ordering, stable-within-group, permutation invariant, all-watched fallback, and composition with the tier shuffle).
- [x] `npx tsc --noEmit` — no errors in project code.
- [x] `npx eslint` on changed files — no errors (warnings are pre-existing).

---
🤖 *Generated by Computer*